### PR TITLE
QA: Work Section Case Study Links

### DIFF
--- a/src/components/BlockFooterLinks.js
+++ b/src/components/BlockFooterLinks.js
@@ -19,7 +19,7 @@ const BlockFooterLinks = props => {
       className='BlockFooterLinks flex flex-row col-8 md:col-5 mxauto px1 md:px0 pb3 md:py0 md:pb15'
     >
       <a 
-        className="small link text-decoration-none pr4"
+        className="small link decoration-none pr4"
         alt='Visit Sanctuary Computer'
         href='/'
         rel="noopener noreferrer"

--- a/src/components/WorkSection.js
+++ b/src/components/WorkSection.js
@@ -132,7 +132,7 @@ class WorkSection extends PureComponent {
                     <div className="flex flex-row flex-wrap">
                       {get(work, 'fields.caseStudySlug', '') && (
                         <Link
-                          className="small link text-decoration-none pb1 pr2"
+                          className="small link decoration-none pb1 pr2"
                           ariaLabel="View case study"
                           to={get(work, 'fields.caseStudySlug', '')}
                           rel="noopener noreferrer"
@@ -219,7 +219,7 @@ class WorkSection extends PureComponent {
               </h2>
               {get(activeProject, 'fields.caseStudySlug', '') && (
                 <Link
-                  className="small link text-decoration-none pb1 pr2"
+                  className="small link decoration-none pb1 pr2"
                   ariaLabel="View case study"
                   to={get(activeProject, 'fields.caseStudySlug', '')}
                   rel="noopener noreferrer"

--- a/src/components/WorkSection.js
+++ b/src/components/WorkSection.js
@@ -132,10 +132,9 @@ class WorkSection extends PureComponent {
                     <div className="flex flex-row flex-wrap">
                       {get(work, 'fields.caseStudySlug', '') && (
                         <Link
-                          className="small link text-no-decoration pb1 pr2"
+                          className="small link text-decoration-none pb1 pr2"
                           ariaLabel="View case study"
                           to={get(work, 'fields.caseStudySlug', '')}
-                          target="_blank"
                           rel="noopener noreferrer"
                         >
                         → View Case Study
@@ -220,10 +219,9 @@ class WorkSection extends PureComponent {
               </h2>
               {get(activeProject, 'fields.caseStudySlug', '') && (
                 <Link
-                  className="small link text-no-decoration pb1 pr2"
+                  className="small link text-decoration-none pb1 pr2"
                   ariaLabel="View case study"
                   to={get(activeProject, 'fields.caseStudySlug', '')}
-                  target="_blank"
                   rel="noopener noreferrer"
                 >
                 → View Case Study

--- a/src/styles/_utils.scss
+++ b/src/styles/_utils.scss
@@ -32,7 +32,3 @@ input,
     padding-bottom: 120px;
   }
 }
-
-.text-decoration-none {
-  text-decoration: none;
-}


### PR DESCRIPTION
- Add correct `text-decoration-none` class
- Do not open in a new tab
