### PR TITLE
Add Second Image to Case Study Block Image

### DIFF
--- a/src/components/BlockImage.js
+++ b/src/components/BlockImage.js
@@ -65,7 +65,7 @@ const BlockImage = props => {
         <div
           className={cx('BlockImage__image-container', {
             'md:col-8 mxauto':
-              imageVariant === 'full' || imageVariant === 'large',
+              imageVariant === 'full' || imageVariant === 'xlarge',
             'md:col-6': imageVariant === 'large',
             'md:col-5': imageVariant === 'medium',
             'md:col-4': imageVariant === 'small'

--- a/src/components/BlockImage.js
+++ b/src/components/BlockImage.js
@@ -13,20 +13,40 @@ import { Image } from 'components/base';
 const BlockImage = props => {
   const fields = get(props, 'block.fields');
   const currentBreakpoint = get(props, 'currentBreakpoint', '');
-  const desktopImage = flattenImageData(get(fields, 'image', {}));
-  const mobileImage = flattenImageData(
-    get(fields, 'mobileImage', desktopImage)
+  const imageHorizontalAlignment = get(
+    fields,
+    'imageHorizontalAlignment',
+    'Center'
+  ).toLowerCase();
+  const imageVerticalAlignment = get(
+    fields,
+    'imageVerticalAlignment',
+    'Top'
+  ).toLowerCase();
+  const imageVariant = get(fields, 'imageVariant', 'Full').toLowerCase();
+  const desktopImageOne = flattenImageData(get(fields, 'imageOne', {}));
+  const desktopImageTwo = flattenImageData(get(fields, 'imageTwo', {}));
+  const mobileImageOne = flattenImageData(
+    get(fields, 'mobileImageOne', desktopImageOne)
   );
-  const image =
+  const mobileImageTwo = flattenImageData(
+    get(fields, 'mobileImageTwo', desktopImageTwo)
+  );
+  const imageOne =
     currentBreakpoint === Breakpoints.EXTRA_SMALL.label ||
     currentBreakpoint === Breakpoints.SMALL.label
-      ? mobileImage
-      : desktopImage;
-  const imageCaption = get(fields, 'imageCaption', '');
+      ? mobileImageOne
+      : desktopImageOne;
+  const imageTwo =
+    currentBreakpoint === Breakpoints.EXTRA_SMALL.label ||
+    currentBreakpoint === Breakpoints.SMALL.label
+      ? mobileImageTwo
+      : desktopImageTwo;
+  const imageOneCaption = get(fields, 'imageOneCaption', '');
+  const imageTwoCaption = get(fields, 'imageTwoCaption', '');
   const marginBottom = get(fields, 'marginBottom', 0);
   const marginTop = get(fields, 'marginTop', 0);
-  const imageAlign = get(fields, 'imageAlign', 'Center').toLowerCase();
-  const imageSize = get(fields, 'imageSize', 'Full').toLowerCase();
+  const hasTwoImages = imageVariant === 'two';
 
   return (
     <div
@@ -34,44 +54,89 @@ const BlockImage = props => {
         marginBottom: `${marginBottom}rem`,
         marginTop: `${marginTop}rem`
       }}
-      className={cx('BlockImage flex px1 md:px0 md:pb10', {
-        'justify-center': imageAlign === 'center',
-        'justify-start md:px1': imageAlign === 'left',
-        'justify-end md:px1': imageAlign === 'right',
-        'pb4': imageCaption,
-        'pb3': !imageCaption
+      className={cx('BlockImage flex px1 pb3 md:pb10', {
+        'justify-center': imageHorizontalAlignment === 'center',
+        'justify-start md:px1': imageHorizontalAlignment === 'left',
+        'justify-end md:px1': imageHorizontalAlignment === 'right',
+        'md:px0': imageVariant === 'full'
       })}
     >
-      <div
-        className={cx('BlockImage__image-container', {
-          'md:col-8 mxauto': imageSize === 'full',
-          'md:col-8 md:px1 mxauto': imageSize === 'xlarge',
-          'md:col-6': imageSize === 'large',
-          'md:col-5': imageSize === 'medium',
-          'md:col-4': imageSize === 'small',
-        })}
-      >
-        <Image
-        className="BlockImage__image h100 w100 hauto fit-cover"
-        alt={image.description}
-        src={image.url}
-        />
-        {imageCaption && <p className="image-caption small color-gray-darkest mt_5">{imageCaption}</p>}
+      {!hasTwoImages && (
+        <div
+          className={cx('BlockImage__image-container', {
+            'md:col-8 mxauto':
+              imageVariant === 'full' || imageVariant === 'large',
+            'md:col-6': imageVariant === 'large',
+            'md:col-5': imageVariant === 'medium',
+            'md:col-4': imageVariant === 'small'
+          })}
+        >
+          <Image
+            className="BlockImage__image h100 w100 hauto fit-cover"
+            alt={imageOne.description}
+            src={imageOne.url}
+          />
+          {imageOneCaption && (
+            <p className="image-caption small color-gray-darkest mt_5">
+              {imageOneCaption}
+            </p>
+          )}
+        </div>
+      )}
+      {hasTwoImages && (
+        <div
+          className={cx(
+            'BlockTwoImages__image-container col-8 flex flex-col sm:flex-row',
+            {
+              'sm:items-start': imageVerticalAlignment === 'top',
+              'sm:items-end': imageVerticalAlignment === 'bottom'
+            }
+          )}
+        >
+          <div className="flex flex-col col-8 sm:col-4 pb3 sm:pb0 sm:mr1">
+            <Image
+              className="BlockTwoImages__image w100"
+              alt={imageOne.description}
+              src={imageOne.url}
+            />
+            {imageOneCaption && (
+              <p className="image-caption small color-gray-darkest mt_5">
+                {imageOneCaption}
+              </p>
+            )}
+          </div>
+          <div className="flex flex-col col-8 sm:col-4">
+            <Image
+              className="BlockTwoImages__image w100"
+              alt={imageTwo.description}
+              src={imageTwo.url}
+            />
+            {imageTwoCaption && (
+              <p className="image-caption small color-gray-darkest mt_5">
+                {imageTwoCaption}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
     </div>
-  </div>
   );
 };
 
 BlockImage.propTypes = {
   block: PropTypes.shape({
     fields: PropTypes.shape({
-      imageAlign: PropTypes.string,
+      imageHorizontalAlignment: PropTypes.string,
+      imageVeticalAlignment: PropTypes.string,
       imageVariant: PropTypes.string,
-      image: ContentfulMedia,
-      mobileImage: ContentfulMedia,
-      imageCaption: PropTypes.string,
+      imageOne: ContentfulMedia,
+      imageTwo: ContentfulMedia,
+      mobileImageOne: ContentfulMedia,
+      mobileImageTwo: ContentfulMedia,
+      imageOneCaption: PropTypes.string,
+      imageTwoCaption: PropTypes.string,
       marginBottom: PropTypes.number,
-      marginTop: PropTypes.number,
+      marginTop: PropTypes.number
     })
   })
 };

--- a/src/components/BlockImage.js
+++ b/src/components/BlockImage.js
@@ -127,7 +127,7 @@ BlockImage.propTypes = {
   block: PropTypes.shape({
     fields: PropTypes.shape({
       imageHorizontalAlignment: PropTypes.string,
-      imageVeticalAlignment: PropTypes.string,
+      imageVerticalAlignment: PropTypes.string,
       imageVariant: PropTypes.string,
       imageOne: ContentfulMedia,
       imageTwo: ContentfulMedia,


### PR DESCRIPTION
- Images have the option to be aligned at the top or bottom and the image should take up whatever height it has. 
- This shouldn't break `/roti` because the image blocks have the previous fields and the new fields. Will delete the previous fields when this is pushed to production. 
- View at `/style-guide`, first two image blocks.
Design:
![Screen Shot 2020-04-13 at 1 05 45 PM](https://user-images.githubusercontent.com/43737723/79141285-81cd6500-7d87-11ea-8d0d-ad6390eea0d7.png)
