### PR TITLE
Case Study Blocks: Add margins from CMS

### DIFF
--- a/src/components/BlockGeneralParagraph.js
+++ b/src/components/BlockGeneralParagraph.js
@@ -9,8 +9,6 @@ const BlockGeneralParagraph = props => {
   const fields = get(props, 'block.fields');
   const header = get(fields, 'header', '');
   const description = get(fields, 'description', '');
-  const marginBottom = get(fields, 'marginBottom', 0);
-  const marginTop = get(fields, 'marginTop', 0);
   const marginBottomDesktop = `md:mb${get(fields, 'marginBottomDesktop', 0)}`;
   const marginTopDesktop = `md:mt${get(fields, 'marginTopDesktop', 0)}`;
   const marginBottomMobile = `mb${get(fields, 'marginBottomMobile', 0)}`;
@@ -43,8 +41,6 @@ BlockGeneralParagraph.propTypes = {
     fields: PropTypes.shape({
       header: PropTypes.string,
       description: PropTypes.string,
-      marginBottom: PropTypes.number,
-      marginTop: PropTypes.number,
       marginBottomDesktop: PropTypes.number,
       marginTopDesktop: PropTypes.number,
       marginBottomMobile: PropTypes.number,

--- a/src/components/BlockGeneralParagraph.js
+++ b/src/components/BlockGeneralParagraph.js
@@ -11,20 +11,28 @@ const BlockGeneralParagraph = props => {
   const description = get(fields, 'description', '');
   const marginBottom = get(fields, 'marginBottom', 0);
   const marginTop = get(fields, 'marginTop', 0);
+  const marginBottomDesktop = `md:mb${get(fields, 'marginBottomDesktop', 0)}`;
+  const marginTopDesktop = `md:mt${get(fields, 'marginTopDesktop', 0)}`;
+  const marginBottomMobile = `mb${get(fields, 'marginBottomMobile', 0)}`;
+  const marginTopMobile = `mt${get(fields, 'marginTopMobile', 0)}`;
 
   return (
     <div
-      style={{
-        marginBottom: `${marginBottom}rem`,
-        marginTop: `${marginTop}rem`
-      }}
-      className="BlockGeneralParagraph flex flex-col md:flex-row col-8 md:col-5 mxauto px1 md:px0 pb3 md:pb10"
+      className={`BlockGeneralParagraph flex flex-col md:flex-row col-8 md:col-5 mxauto px1 md:px0 ${marginBottomMobile} ${marginBottomDesktop} ${marginTopMobile} ${marginTopDesktop}`}
     >
       {header && (
-        <h1 className="BlockGeneralParagraph__header paragraph col-8 md:col-4 pb2 md:pb0 md:pr2">{header}</h1>
+        <h1 className="BlockGeneralParagraph__header paragraph col-8 md:col-4 pb2 md:pb0 md:pr2">
+          {header}
+        </h1>
       )}
       <div className="col-8 md:col-4">
-        {description && <Markdown className="BlockGeneralParagraph__paragraph" fontSize="small" src={description} />}
+        {description && (
+          <Markdown
+            className="BlockGeneralParagraph__paragraph"
+            fontSize="small"
+            src={description}
+          />
+        )}
       </div>
     </div>
   );
@@ -36,7 +44,11 @@ BlockGeneralParagraph.propTypes = {
       header: PropTypes.string,
       description: PropTypes.string,
       marginBottom: PropTypes.number,
-      marginTop: PropTypes.number
+      marginTop: PropTypes.number,
+      marginBottomDesktop: PropTypes.number,
+      marginTopDesktop: PropTypes.number,
+      marginBottomMobile: PropTypes.number,
+      marginTopMobile: PropTypes.number
     })
   })
 };

--- a/src/components/BlockImageText.js
+++ b/src/components/BlockImageText.js
@@ -31,16 +31,14 @@ const BlockImageText = props => {
     'imageTextAlign',
     'Image:Text'
   ).toLowerCase();
-  const marginBottom = get(fields, 'marginBottom', 1);
-  const marginTop = get(fields, 'marginTop', 1);
+  const marginBottomDesktop = `md:mb${get(fields, 'marginBottomDesktop', 0)}`;
+  const marginTopDesktop = `md:mt${get(fields, 'marginTopDesktop', 0)}`;
+  const marginBottomMobile = `mb${get(fields, 'marginBottomMobile', 0)}`;
+  const marginTopMobile = `mt${get(fields, 'marginTopMobile', 0)}`;
 
   return (
     <div
-      style={{
-        marginBottom: `${marginBottom}rem`,
-        marginTop: `${marginTop}rem`
-      }}
-      className="BlockImageText px1 flex flex-col"
+      className={`BlockImageText px1 flex flex-col ${marginBottomMobile} ${marginBottomDesktop} ${marginTopMobile} ${marginTopDesktop}`}
     >
       {header && headerOnTop && (
         <p
@@ -146,8 +144,10 @@ BlockImageText.propTypes = {
       descriptionAlign: PropTypes.string,
       descriptionWidth: PropTypes.number,
       imageTextAlign: PropTypes.string,
-      marginBottom: PropTypes.number,
-      marginTop: PropTypes.number
+      marginBottomDesktop: PropTypes.number,
+      marginTopDesktop: PropTypes.number,
+      marginBottomMobile: PropTypes.number,
+      marginTopMobile: PropTypes.number
     })
   })
 };

--- a/src/components/BlockLargeParagraph.js
+++ b/src/components/BlockLargeParagraph.js
@@ -6,8 +6,6 @@ import get from 'utils/get';
 const BlockLargeParagraph = props => {
   const fields = get(props, 'block.fields');
   const description = get(fields, 'description', '');
-  const marginBottom = get(fields, 'marginBottom', 0);
-  const marginTop = get(fields, 'marginTop', 0);
   const marginBottomDesktop = `md:mb${get(fields, 'marginBottomDesktop', 0)}`;
   const marginTopDesktop = `md:mt${get(fields, 'marginTopDesktop', 0)}`;
   const marginBottomMobile = `mb${get(fields, 'marginBottomMobile', 0)}`;
@@ -30,8 +28,6 @@ BlockLargeParagraph.propTypes = {
   block: PropTypes.shape({
     fields: PropTypes.shape({
       description: PropTypes.string,
-      marginBottom: PropTypes.number,
-      marginTop: PropTypes.number,
       marginBottomDesktop: PropTypes.number,
       marginTopDesktop: PropTypes.number,
       marginBottomMobile: PropTypes.number,

--- a/src/components/BlockLargeParagraph.js
+++ b/src/components/BlockLargeParagraph.js
@@ -8,17 +8,19 @@ const BlockLargeParagraph = props => {
   const description = get(fields, 'description', '');
   const marginBottom = get(fields, 'marginBottom', 0);
   const marginTop = get(fields, 'marginTop', 0);
+  const marginBottomDesktop = `md:mb${get(fields, 'marginBottomDesktop', 0)}`;
+  const marginTopDesktop = `md:mt${get(fields, 'marginTopDesktop', 0)}`;
+  const marginBottomMobile = `mb${get(fields, 'marginBottomMobile', 0)}`;
+  const marginTopMobile = `mt${get(fields, 'marginTopMobile', 0)}`;
 
   return (
     <div
-      style={{
-        marginBottom: `${marginBottom}rem`,
-        marginTop: `${marginTop}rem`
-      }}
-      className='BlockLargeParagraph flex col-8 md:col-5 px1 md:px0 pb3 mxauto'
+      className={`BlockLargeParagraph flex col-8 md:col-5 px1 md:px0 ${marginBottomMobile} ${marginBottomDesktop} ${marginTopMobile} ${marginTopDesktop} mxauto`}
     >
       {description && (
-        <p className="BlockLargeParagraph__description paragraph">{description}</p>
+        <p className="BlockLargeParagraph__description paragraph">
+          {description}
+        </p>
       )}
     </div>
   );
@@ -29,7 +31,11 @@ BlockLargeParagraph.propTypes = {
     fields: PropTypes.shape({
       description: PropTypes.string,
       marginBottom: PropTypes.number,
-      marginTop: PropTypes.number
+      marginTop: PropTypes.number,
+      marginBottomDesktop: PropTypes.number,
+      marginTopDesktop: PropTypes.number,
+      marginBottomMobile: PropTypes.number,
+      marginTopMobile: PropTypes.number
     })
   })
 };

--- a/src/components/BlockThreeColumnList.js
+++ b/src/components/BlockThreeColumnList.js
@@ -16,37 +16,64 @@ const BlockThreeColumnList = props => {
   const columnThreeNumber = get(fields, 'columnThreeNumber', '');
   const marginBottom = get(fields, 'marginBottom', 0);
   const marginTop = get(fields, 'marginTop', 0);
+  const marginBottomDesktop = `md:mb${get(fields, 'marginBottomDesktop', 0)}`;
+  const marginTopDesktop = `md:mt${get(fields, 'marginTopDesktop', 0)}`;
+  const marginBottomMobile = `mb${get(fields, 'marginBottomMobile', 0)}`;
+  const marginTopMobile = `mt${get(fields, 'marginTopMobile', 0)}`;
 
   return (
     <div
-      style={{
-        marginBottom: `${marginBottom}rem`,
-        marginTop: `${marginTop}rem`
-      }}
-      className="BlockThreeColumnList flex flex-col col-8 md:col-5 mxauto px1 md:px0 pb3 md:pb7"
+      className={`BlockThreeColumnList flex flex-col col-8 md:col-5 mxauto px1 md:px0 ${marginBottomMobile} ${marginBottomDesktop} ${marginTopMobile} ${marginTopDesktop}`}
     >
       {header && (
-        <h1 className="BlockThreeColumnList__header small col-8 md:col-4 pb2">{header}</h1>
+        <h1 className="BlockThreeColumnList__header small col-8 md:col-4 pb2">
+          {header}
+        </h1>
       )}
-        <ol className="flex flex-col md:flex-row justify-between">
-          {columnOne && 
-            <li className="flex flex-row pb2 md:pb0 md:pr1">
-              {columnOneNumber && <span className="BlockThreeColumnList__number small pr1">{columnOneNumber}</span>}
-              <Markdown className="BlockThreeColumnList__list-item" fontSize="small" src={columnOne}/>
-            </li>
-          }
-          {columnTwo && 
-            <li className="flex flex-row pb2 md:pb0 md:pr1">
-              {columnTwoNumber && <span className="BlockThreeColumnList__number small pr1">{columnTwoNumber}</span>}
-              <Markdown className="BlockThreeColumnList__list-item" fontSize="small" src={columnTwo}/>
-            </li>
-          }
-          {columnThree && 
-            <li className="flex flex-row md:pb0 md:pr1">
-              {columnThreeNumber && <span className="BlockThreeColumnList__number small pr1">{columnThreeNumber}</span>}
-              <Markdown className="BlockThreeColumnList__list-item" fontSize="small" src={columnThree}/>
-            </li>}
-        </ol>
+      <ol className="flex flex-col md:flex-row justify-between">
+        {columnOne && (
+          <li className="flex flex-row pb2 md:pb0 md:pr1">
+            {columnOneNumber && (
+              <span className="BlockThreeColumnList__number small pr1">
+                {columnOneNumber}
+              </span>
+            )}
+            <Markdown
+              className="BlockThreeColumnList__list-item"
+              fontSize="small"
+              src={columnOne}
+            />
+          </li>
+        )}
+        {columnTwo && (
+          <li className="flex flex-row pb2 md:pb0 md:pr1">
+            {columnTwoNumber && (
+              <span className="BlockThreeColumnList__number small pr1">
+                {columnTwoNumber}
+              </span>
+            )}
+            <Markdown
+              className="BlockThreeColumnList__list-item"
+              fontSize="small"
+              src={columnTwo}
+            />
+          </li>
+        )}
+        {columnThree && (
+          <li className="flex flex-row md:pb0 md:pr1">
+            {columnThreeNumber && (
+              <span className="BlockThreeColumnList__number small pr1">
+                {columnThreeNumber}
+              </span>
+            )}
+            <Markdown
+              className="BlockThreeColumnList__list-item"
+              fontSize="small"
+              src={columnThree}
+            />
+          </li>
+        )}
+      </ol>
     </div>
   );
 };
@@ -62,7 +89,11 @@ BlockThreeColumnList.propTypes = {
       columnTwoNumber: PropTypes.string,
       columnThreeNumber: PropTypes.string,
       marginBottom: PropTypes.number,
-      marginTop: PropTypes.number
+      marginTop: PropTypes.number,
+      marginBottomDesktop: PropTypes.number,
+      marginTopDesktop: PropTypes.number,
+      marginBottomMobile: PropTypes.number,
+      marginTopMobile: PropTypes.number
     })
   })
 };

--- a/src/components/BlockThreeColumnList.js
+++ b/src/components/BlockThreeColumnList.js
@@ -14,8 +14,6 @@ const BlockThreeColumnList = props => {
   const columnTwoNumber = get(fields, 'columnTwoNumber', '');
   const columnThree = get(fields, 'columnThree', '');
   const columnThreeNumber = get(fields, 'columnThreeNumber', '');
-  const marginBottom = get(fields, 'marginBottom', 0);
-  const marginTop = get(fields, 'marginTop', 0);
   const marginBottomDesktop = `md:mb${get(fields, 'marginBottomDesktop', 0)}`;
   const marginTopDesktop = `md:mt${get(fields, 'marginTopDesktop', 0)}`;
   const marginBottomMobile = `mb${get(fields, 'marginBottomMobile', 0)}`;
@@ -88,8 +86,6 @@ BlockThreeColumnList.propTypes = {
       columnOneNumber: PropTypes.string,
       columnTwoNumber: PropTypes.string,
       columnThreeNumber: PropTypes.string,
-      marginBottom: PropTypes.number,
-      marginTop: PropTypes.number,
       marginBottomDesktop: PropTypes.number,
       marginTopDesktop: PropTypes.number,
       marginBottomMobile: PropTypes.number,

--- a/src/components/BlockVideo.js
+++ b/src/components/BlockVideo.js
@@ -12,14 +12,22 @@ const BlockVideo = props => {
   const videoSize = get(props, 'block.fields.videoSize', 'Full').toLowerCase();
   const autoPlay = get(fields, 'autoPlayVideo', true);
   const loop = get(fields, 'loopVideo', true);
+  const marginBottomDesktop = `md:mb${get(fields, 'marginBottomDesktop', 0)}`;
+  const marginTopDesktop = `md:mt${get(fields, 'marginTopDesktop', 0)}`;
+  const marginBottomMobile = `mb${get(fields, 'marginBottomMobile', 0)}`;
+  const marginTopMobile = `mt${get(fields, 'marginTopMobile', 0)}`;
 
   return (
     <div
-    className={cx('BlockVideo pb3 md:pb7 mxauto', {
-      'md:col-8': videoSize === 'full',
-      'md:col-8 px1': videoSize === 'xlarge',
-      'md:col-6 px1 md:px0': videoSize === 'large'
-    })}>
+      className={cx(
+        `BlockVideo ${marginBottomMobile} ${marginBottomDesktop} ${marginTopMobile} ${marginTopDesktop} mxauto`,
+        {
+          'md:col-8': videoSize === 'full',
+          'md:col-8 px1': videoSize === 'xlarge',
+          'md:col-6 px1 md:px0': videoSize === 'large'
+        }
+      )}
+    >
       <video
         className="BlockVideo__video block hauto w100 mxauto"
         autoPlay={autoPlay}
@@ -27,9 +35,7 @@ const BlockVideo = props => {
         muted
         playsInline
       >
-        <source
-          src={get(video, 'fields.file.url', '')}
-        ></source>
+        <source src={get(video, 'fields.file.url', '')}></source>
       </video>
     </div>
   );
@@ -42,6 +48,10 @@ BlockVideo.propTypes = {
       videoSize: PropTypes.string,
       autoPlay: PropTypes.bool,
       loop: PropTypes.bool,
+      marginBottomDesktop: PropTypes.number,
+      marginTopDesktop: PropTypes.number,
+      marginBottomMobile: PropTypes.number,
+      marginTopMobile: PropTypes.number
     })
   })
 };

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -12,5 +12,4 @@
 @import './components/BlockImageText.scss';
 @import './components/BlockHero.scss';
 @import './components/BlockGeneralParagraph.scss';
-@import './components/BlockLargeParagraph.scss';
 @import './components/BlockThreeColumnList.scss';

--- a/src/styles/components/BlockGeneralParagraph.scss
+++ b/src/styles/components/BlockGeneralParagraph.scss
@@ -1,8 +1,4 @@
 .BlockGeneralParagraph {
-  // @media(max-width: 831px) {
-  //   margin-top: 0!important;
-  // }
-
   &__paragraph > div > span > p {
     line-height: 1.5rem;
   }

--- a/src/styles/components/BlockGeneralParagraph.scss
+++ b/src/styles/components/BlockGeneralParagraph.scss
@@ -1,7 +1,7 @@
 .BlockGeneralParagraph {
-  @media(max-width: 831px) {
-    margin-top: 0!important;
-  }
+  // @media(max-width: 831px) {
+  //   margin-top: 0!important;
+  // }
 
   &__paragraph > div > span > p {
     line-height: 1.5rem;

--- a/src/styles/components/BlockLargeParagraph.scss
+++ b/src/styles/components/BlockLargeParagraph.scss
@@ -1,6 +1,6 @@
 .BlockLargeParagraph {
-  @media(max-width: 831px) {
-    margin-top: 0!important;
-    margin-bottom: 0!important;
-  }
+  // @media(max-width: 831px) {
+  //   margin-top: 0!important;
+  //   margin-bottom: 0!important;
+  // }
 }

--- a/src/styles/components/BlockLargeParagraph.scss
+++ b/src/styles/components/BlockLargeParagraph.scss
@@ -1,6 +1,0 @@
-.BlockLargeParagraph {
-  // @media(max-width: 831px) {
-  //   margin-top: 0!important;
-  //   margin-bottom: 0!important;
-  // }
-}


### PR DESCRIPTION
- From the designs, some of the blocks need a specific margin or padding depending on their location, so adding the margins directly in the CMS is easier. 
- Help text in the CMS: `This will default to '0' (unit: rem). Mobile size is below 'md' screens, and Desktop size is 'md' screens and up. IMPORTANT: To work, this number must be added to $spacing-units in _config.scss if it is not already included.`

Part 2: Will update `BlockImage` when #75 is merged. 