### PR TITLE
Fix typo in Meta, Remove duplicates in index.html 

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,22 +10,7 @@
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
   <link rel="stylesheet" type="text/css" href="https://fonts.sanctuary.computer/AustinNewsDeck/styles.css">
   <link rel="stylesheet" type="text/css" href="https://fonts.sanctuary.computer/AtlasGrotesk/styles.css">
-
-  <title>SANCTU COMPU - The Safest Place on Earth.</title>
-  <meta name="description" content="Sanctuary Computer (sanctu • compu) is an artful technology studio in Chinatown, NYC."/>
-
-  <meta name="twitter:card" content="summary" />
-  <meta name="twitter:site" content="@sanctucompu" />
-  <meta name="twitter:title" content="SANCTU COMPU - The Safest Place on Earth." />
-  <meta name="twitter:description" content="Sanctuary Computer (sanctu • compu) is an artful technology studio in Chinatown, NYC." />
-  <meta name="twitter:image" content="%PUBLIC_URL%/assets/sanctu-share-card.jpg" />
-
-  <meta property="og:title" content="SANCTU COMPU - The Safest Place on Earth." />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://www.sanctuary.computer/" />
-  <meta property="og:image" content="%PUBLIC_URL%/assets/sanctu-share-card.jpg" />
-  <meta property="og:description" content="Sanctuary Computer (sanctu • compu) is an artful technology studio in Chinatown, NYC." />
-
+  
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-88778470-4"></script>
   <script>

--- a/src/components/Meta.js
+++ b/src/components/Meta.js
@@ -24,7 +24,7 @@ const Meta = ({ model }) => {
       <meta property="og:site_name" content="Sanctuary Computer" />
       <meta property="og:locale" content="en_US" />
       <meta name="twitter:title" content={seoTitle} />
-      <meta name="twitter:seoDescription" content={seoDescription} />
+      <meta name="twitter:description" content={seoDescription} />
       <meta name="twitter:image" content={seoShareCard} />
       <meta name="twitter:site" content="@sanctucompu" />
       <meta name="twitter:creator" content="@sanctucompu" />


### PR DESCRIPTION
`/roti`

![Screen Shot 2020-04-15 at 6 23 33 PM](https://user-images.githubusercontent.com/43737723/79394773-46c56000-7f46-11ea-9886-e87311f571c3.png)


`/`

![Screen Shot 2020-04-15 at 6 23 50 PM](https://user-images.githubusercontent.com/43737723/79394779-47f68d00-7f46-11ea-97ce-03bca858922c.png)
