### PR TITLE
Add Block Two Column, Add Half Width Video Variant

### DIFF
--- a/src/components/BlockTwoColumn.js
+++ b/src/components/BlockTwoColumn.js
@@ -25,7 +25,7 @@ const BlockTwoColumn = props => {
         marginBottom: `${marginBottom}rem`,
         marginTop: `${marginTop}rem`
       }}
-      className="BlockTwoColumn flex flex-col md:flex-row col-8 xl:col-6 px1 xl:px0 pb3 mxauto"
+      className="BlockTwoColumn flex flex-col md:flex-row col-8 xl:col-6 px1 xl:px0 pb md:pb7 mxauto"
     >
       {header && (
         <p className="BlockTwoColumn__header paragraph col-8 md:col-2 pb1 md:pb0 md:pr2">

--- a/src/components/BlockTwoColumn.js
+++ b/src/components/BlockTwoColumn.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import get from 'utils/get';
+import cx from 'classnames';
+
+const BlockTwoColumn = props => {
+  const fields = get(props, 'block.fields');
+  const header = get(fields, 'header', '');
+  const sectionOneTitle = get(fields, 'sectionOneTitle', '');
+  const sectionOneText = get(fields, 'sectionOneText', '');
+  const sectionTwoTitle = get(fields, 'sectionTwoTitle', '');
+  const sectionTwoText = get(fields, 'sectionTwoText', '');
+  const sectionThreeTitle = get(fields, 'sectionThreeTitle', '');
+  const sectionThreeText = get(fields, 'sectionThreeText', '');
+  const sectionFourTitle = get(fields, 'sectionFourTitle', '');
+  const sectionFourText = get(fields, 'sectionFourText', '');
+  const marginBottom = get(fields, 'marginBottom', 0);
+  const marginTop = get(fields, 'marginTop', 0);
+  const hasTwoRows = sectionOneText && sectionTwoText && sectionThreeText;
+
+  return (
+    <div
+      style={{
+        marginBottom: `${marginBottom}rem`,
+        marginTop: `${marginTop}rem`
+      }}
+      className="BlockTwoColumn flex flex-col md:flex-row col-8 xl:col-6 px1 xl:px0 pb3 mxauto"
+    >
+      {header && (
+        <p className="BlockTwoColumn__header paragraph col-8 md:col-2 pb1 md:pb0 md:pr2">
+          {header}
+        </p>
+      )}
+      <div className="flex flex-col col-8 md:col-6">
+        <div className="flex flex-col md:flex-row md:pb3">
+          {sectionOneText && (
+            <div className="BlockTwoColumn__paragraph Markdown--small flex flex-col col-8 md:col-4 pb2 md:pb0 md:mr1">
+              {sectionOneTitle && <p className="pb1">{sectionOneTitle}</p>}
+              <p>{sectionOneText}</p>
+            </div>
+          )}
+          {sectionTwoText && (
+            <div
+              className={cx(
+                'BlockTwoColumn__paragraph Markdown--small flex flex-col col-8 md:col-4 md:pb0',
+                {
+                  pb2: hasTwoRows
+                }
+              )}
+            >
+              {sectionTwoTitle && <p className="pb1">{sectionTwoTitle}</p>}
+              <p>{sectionTwoText}</p>
+            </div>
+          )}
+        </div>
+        <div className="flex flex-col md:flex-row">
+          {sectionThreeText && (
+            <div
+              className={cx(
+                'BlockTwoColumn__paragraph Markdown--small flex flex-col col-8 md:col-4 md:pb0 md:mr1',
+                {
+                  pb2: sectionFourText
+                }
+              )}
+            >
+              {sectionThreeTitle && <p className="pb1">{sectionThreeTitle}</p>}
+              <p>{sectionThreeText}</p>
+            </div>
+          )}
+          {sectionFourText && (
+            <div className="BlockTwoColumn__paragraph Markdown--small flex flex-col col-8 md:col-4">
+              {sectionFourTitle && <p className="pb1">{sectionFourTitle}</p>}
+              <p>{sectionFourText}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+BlockTwoColumn.propTypes = {
+  block: PropTypes.shape({
+    fields: PropTypes.shape({
+      header: PropTypes.string,
+      sectionOneTitle: PropTypes.string,
+      sectionTwoTitle: PropTypes.string,
+      sectionThreeTitle: PropTypes.string,
+      sectionFourTitle: PropTypes.string,
+      sectionOneText: PropTypes.string,
+      sectionTwoText: PropTypes.string,
+      sectionThreeText: PropTypes.string,
+      sectionFourText: PropTypes.string,
+      marginBottom: PropTypes.number,
+      marginTop: PropTypes.number
+    })
+  })
+};
+
+export default BlockTwoColumn;

--- a/src/components/BlockTwoColumn.js
+++ b/src/components/BlockTwoColumn.js
@@ -17,7 +17,6 @@ const BlockTwoColumn = props => {
   const sectionFourText = get(fields, 'sectionFourText', '');
   const marginBottom = get(fields, 'marginBottom', 0);
   const marginTop = get(fields, 'marginTop', 0);
-  const hasTwoRows = sectionOneText && sectionTwoText && sectionThreeText;
 
   return (
     <div
@@ -45,7 +44,7 @@ const BlockTwoColumn = props => {
               className={cx(
                 'BlockTwoColumn__paragraph Markdown--small flex flex-col col-8 md:col-4 md:pb0',
                 {
-                  pb2: hasTwoRows
+                  pb2: sectionThreeText
                 }
               )}
             >

--- a/src/components/BlockVideo.js
+++ b/src/components/BlockVideo.js
@@ -15,22 +15,32 @@ const BlockVideo = props => {
 
   return (
     <div
-    className={cx('BlockVideo pb3 md:pb7 mxauto', {
-      'md:col-8': videoSize === 'full',
-      'md:col-8 px1': videoSize === 'xlarge',
-      'md:col-6 px1 md:px0': videoSize === 'large'
-    })}>
-      <video
-        className="BlockVideo__video block hauto w100 mxauto"
-        autoPlay={autoPlay}
-        loop={loop}
-        muted
-        playsInline
+      className={cx('BlockVideo pb3 md:pb7', {
+        'md:col-8 mxauto': videoSize === 'full',
+        'md:col-8 px1 mxauto': videoSize === 'xlarge',
+        'md:col-6 px1 md:px0 mxauto': videoSize === 'large',
+        'md:col-8 px1 md:px0 flex sm:justify-start':
+          videoSize === 'half-left-align',
+        'md:col-8 px1 md:px0 flex sm:justify-end':
+          videoSize === 'half-right-align'
+      })}
+    >
+      <div
+        className={cx({
+          'flex sm:col-4 sm:pl1': videoSize === 'half-left-align',
+          'flex sm:col-4 sm:pr1': videoSize === 'half-right-align'
+        })}
       >
-        <source
-          src={get(video, 'fields.file.url', '')}
-        ></source>
-      </video>
+        <video
+          className="BlockVideo__video block hauto w100"
+          autoPlay={autoPlay}
+          loop={loop}
+          muted
+          playsInline
+        >
+          <source src={get(video, 'fields.file.url', '')}></source>
+        </video>
+      </div>
     </div>
   );
 };
@@ -41,7 +51,7 @@ BlockVideo.propTypes = {
       video: ContentfulMedia,
       videoSize: PropTypes.string,
       autoPlay: PropTypes.bool,
-      loop: PropTypes.bool,
+      loop: PropTypes.bool
     })
   })
 };

--- a/src/components/BlockVideo.js
+++ b/src/components/BlockVideo.js
@@ -27,8 +27,8 @@ const BlockVideo = props => {
     >
       <div
         className={cx({
-          'flex sm:col-4 sm:pl1': videoSize === 'half-left-align',
-          'flex sm:col-4 sm:pr1': videoSize === 'half-right-align'
+          'sm:col-4 sm:pl1': videoSize === 'half-left-align',
+          'sm:col-4 sm:pr1': videoSize === 'half-right-align'
         })}
       >
         <video

--- a/src/components/CaseStudyBlockSwitch.js
+++ b/src/components/CaseStudyBlockSwitch.js
@@ -11,6 +11,7 @@ import BlockHero from 'components/BlockHero';
 import BlockVideo from 'components/BlockVideo';
 import BlockFooterLinks from 'components/BlockFooterLinks';
 import BlockViewMore from 'components/BlockViewMore';
+import BlockTwoColumn from 'components/BlockTwoColumn';
 
 const CaseStudyBlockSwitch = props => {
   const { block } = props;
@@ -38,6 +39,8 @@ const CaseStudyBlockSwitch = props => {
         return <BlockFooterLinks block={block} />;
       case 'caseStudyBlockViewMore':
         return <BlockViewMore block={block} />;
+      case 'caseStudyBlockTwoColumn':
+        return <BlockTwoColumn block={block} />;
       default:
         return null;
     }

--- a/src/styles/_components.scss
+++ b/src/styles/_components.scss
@@ -16,3 +16,4 @@
 @import './components/BlockThreeColumnList.scss';
 @import './components/CaseStudyTopNav.scss';
 @import './components/BlockViewMore.scss';
+@import './components/BlockTwoColumn.scss';

--- a/src/styles/components/BlockHero.scss
+++ b/src/styles/components/BlockHero.scss
@@ -6,6 +6,8 @@
 
     @include media('sm-up') {
       font-size: 2.5rem;
+      line-height: 3rem;
+      padding-right: 3.5rem;
     }
   }
 

--- a/src/styles/components/BlockTwoColumn.scss
+++ b/src/styles/components/BlockTwoColumn.scss
@@ -1,0 +1,23 @@
+.BlockTwoColumn {
+  &__header {
+    @include media('md-up') {
+      &::before {
+        content: '';
+        display: block;
+        margin: -0.45rem 0;
+      }
+    }
+
+    @include media('lg-up') {
+      &::before {
+        content: '';
+        display: block;
+        margin: -0.5rem 0;
+      }
+    }
+  }
+
+  &__paragraph > p {
+    line-height: 1.5rem;
+  }
+}


### PR DESCRIPTION
View at `/capabilities`

- Also adds a half width video variant (view at `/nobel`)

Preview:
![Screen Shot 2020-04-20 at 7 36 26 PM](https://user-images.githubusercontent.com/43737723/79809400-5b3a9b80-833e-11ea-901b-700956093068.png)
![Screen Shot 2020-04-20 at 7 36 50 PM](https://user-images.githubusercontent.com/43737723/79809404-5d9cf580-833e-11ea-9b11-a6ba218a2d20.png)
