### PR TITLE
Fix position of italicized link in Intro Section Paragraph

### DIFF
--- a/src/styles/components/Markdown.scss
+++ b/src/styles/components/Markdown.scss
@@ -10,8 +10,7 @@
       margin-bottom: $p-xl-line-height;
     }
 
-    > em,
-    > em a {
+    > em {
       @extend .tiny;
       white-space: nowrap;
       position: relative;


### PR DESCRIPTION
Before: 
![Screen Shot 2020-04-23 at 1 47 42 PM](https://user-images.githubusercontent.com/43737723/80131978-075fca80-8569-11ea-8ef0-3cf856748259.png)

After: 
![Screen Shot 2020-04-23 at 1 45 36 PM](https://user-images.githubusercontent.com/43737723/80131905-f0b97380-8568-11ea-980f-49b40bd5141c.png)
