### PR TITLE
render night mode only when it is enabled

### DIFF
--- a/components/Overlay.js
+++ b/components/Overlay.js
@@ -11,10 +11,9 @@ const Overlay = ({ socialMedia, shouldShowOverlay }) => {
     <div
       aria-hidden={!shouldShowOverlay}
       className={cx(
-        'Overlay fixed vw100 vh100 flex flex-col overflow-hidden col-12 bg-color-gray-darkest color-white z3',
+        'Overlay fixed vw100 vh100 flex flex-col overflow-hidden col-12 bg-color-gray-darkest color-white z3 opacity-0',
         {
-          'Overlay--active opacity-1': shouldShowOverlay,
-          'opacity-0': !shouldShowOverlay
+          'Overlay--active': !!shouldShowOverlay
         }
       )}
     >

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment, PureComponent } from 'react';
+import React, { Fragment, useState, useEffect } from 'react';
 import get from 'utils/get';
 
 import ContentfulClient from 'lib/ContentfulClient';
@@ -17,151 +17,157 @@ const dayStartTimeInHours = 7; // 7 AM
 const dayEndTimeInHours = 19; // 7 PM
 let timerID = null;
 
-class MainView extends PureComponent {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      shouldShowOverlay: this.shouldShowOverlay()
-    };
-
-    if (typeof window !== "undefined" && window.HackerDojo) {
-      window.HackerDojo.on('enableNightmode', () => {
-        this.setState({
-          shouldShowOverlay: true
-        });
+const MainView = (props) => {
+  const getShouldShowOverlay = () => {
+    if (typeof window !== 'undefined') {
+      const now = new Date();
+      const currentTimeInHours = now.getHours();
   
-        clearInterval(timerID);
-      });
-  
-      window.HackerDojo.on('disableNightmode', () => {
-        this.setState({
-          shouldShowOverlay: false
-        });
-  
-        clearInterval(timerID);
-      });
+      return currentTimeInHours < dayStartTimeInHours || currentTimeInHours >= dayEndTimeInHours;
+    } else {
+      return false;
     }
-  }
-
-  componentDidUpdate() {
-    this.toggleDocumentClass();
-  }
-
-  componentDidMount() {
-    timerID = setInterval(() => {
-      this.setState({
-        shouldShowOverlay: this.shouldShowOverlay()
-      });
-    }, 1000);
-
-    this.toggleDocumentClass();
-  }
-
-  componentWillUnmount() {
-    clearInterval(timerID);
-
-    const html = document.documentElement;
-    html && html.classList.remove('overlay-is-active');
-  }
-
-  shouldShowOverlay = () => {
-    const now = new Date();
-    const currentTimeInHours = now.getHours();
-
-    const shouldShowOverlay =
-      currentTimeInHours < dayStartTimeInHours ||
-      currentTimeInHours >= dayEndTimeInHours;
-
-    return shouldShowOverlay;
   };
 
-  toggleDocumentClass = () => {
+  const [shouldShowOverlay, setShouldShowOverlay] = useState(false)
+  const [windowAndHackerDojoIsAvailable, setWindowAndHackerDojoIsAvailable] = useState(false)
+  const [renderContent, setRenderContent] = useState(false)
+
+  const toggleDocumentClass = () => {
     const html = document.documentElement;
 
-    if (this.state.shouldShowOverlay) {
+    if (shouldShowOverlay) {
       html && html.classList.add('overlay-is-active');
     } else {
       html && html.classList.remove('overlay-is-active');
     }
   };
 
-  render() {
-    const now = new Date();
-    const currentTimeInHours = now.getHours();
-    console.log(this.state.shouldShowOverlay, currentTimeInHours, dayEndTimeInHours)
-    const model = this.props.model;
-
-    if (!model || model.isError) return <h1>Something went wrong...</h1>;
-
-    return (
-      <Fragment>
-        <Meta model={model} />
-        <Overlay
-          socialMedia={get(model, 'fields.socialMedia.simpleFragments', {})}
-          shouldShowOverlay={this.state.shouldShowOverlay}
-        />
-        <div
-          aria-hidden={this.state.shouldShowOverlay}
-          className="flex md:flex-row flex-col"
-        >
-          <div className="col-8 flex flex-col sticky-spacer">
-            <IntroSectionImages images={get(model, 'fields.introImages', {})} />
-            <AboutSection
-              whatWeDo={get(model, 'fields.whatWeDo.simpleFragments', {})}
-              selectedClients={get(
-                model,
-                'fields.selectedClients.simpleFragments',
-                {}
-              )}
-              technologyStack={get(
-                model,
-                'fields.technologyStack.simpleFragments',
-                {}
-              )}
-              software={get(model, 'fields.software.simpleFragments', {})}
-              collaborators={get(
-                model,
-                'fields.collaborators.simpleFragments',
-                {}
-              )}
-            />
-          </div>
-          <div className="col-8 flex order-first md:order-last">
-            <IntroSectionParagraph
-              introParagraph={get(model, 'fields.introParagraph')}
-            />
-          </div>
-        </div>
-        <div aria-hidden={this.state.shouldShowOverlay}>
-          <WorkSection selectedWorks={get(model, 'fields.selectedWorks', [])} />
-        </div>
-        <div aria-hidden={this.state.shouldShowOverlay}>
-          <Gallery
-            images={get(model, 'fields.gallery', {})}
-            settingExpectations={get(model, 'fields.settingExpectations')}
-            recentArticles={get(
-              model,
-              'fields.recentArticles.simpleFragments',
-              {}
-            )}
-            socialMedia={get(model, 'fields.socialMedia.simpleFragments', {})}
-            openSourceProjects={get(
-              model,
-              'fields.openSourceProjects.simpleFragments',
-              {}
-            )}
-            availablePositions={get(
-              model,
-              'fields.availablePositions.simpleFragments',
-              {}
-            )}
-          />
-        </div>
-        <Footer hidden={this.state.shouldShowOverlay} />
-      </Fragment>
-    );
+  const addToggleNightmode = () => {
+    if (typeof window !== "undefined" && !!window.HackerDojo) {
+      window.HackerDojo.on('enableNightmode', () => {
+        setShouldShowOverlay(true)
+        clearInterval(timerID);
+      });
+  
+      window.HackerDojo.on('disableNightmode', () => {
+        setShouldShowOverlay(false)
+        clearInterval(timerID);
+      });
+    } 
   }
+
+  const getWindowAndHackerDojoIsAvailable = () => {
+    if (!windowAndHackerDojoIsAvailable && typeof window !== "undefined" && !!window.HackerDojo) {
+      setWindowAndHackerDojoIsAvailable(true)
+    }
+  }
+
+  useEffect(() => {
+    setShouldShowOverlay(getShouldShowOverlay())
+    getWindowAndHackerDojoIsAvailable()
+
+    timerID = setInterval(() => {
+      setShouldShowOverlay(getShouldShowOverlay())
+      getWindowAndHackerDojoIsAvailable()
+    }, 1000);
+
+    toggleDocumentClass();
+    setRenderContent(true)
+
+    return () => {
+      clearInterval(timerID);
+
+      const html = document.documentElement;
+      html && html.classList.remove('overlay-is-active');
+    }
+  }, []);
+
+
+  useEffect(() => {
+    addToggleNightmode()
+  }, [addToggleNightmode, windowAndHackerDojoIsAvailable])
+  
+
+  useEffect(() => {
+    toggleDocumentClass();
+  }, [shouldShowOverlay])
+
+  const model = props.model;
+
+  if (!model || model.isError) return <h1>Something went wrong...</h1>;
+
+  return (
+    <Fragment>
+      <Meta model={model} />
+      <Overlay
+        socialMedia={get(model, 'fields.socialMedia.simpleFragments', {})}
+        shouldShowOverlay={shouldShowOverlay}
+      />
+      {!shouldShowOverlay && renderContent && (
+        <div>
+          <div
+            aria-hidden={shouldShowOverlay}
+            className="flex md:flex-row flex-col"
+          >
+            <div className="col-8 flex flex-col sticky-spacer">
+              <IntroSectionImages images={get(model, 'fields.introImages', {})} />
+              <AboutSection
+                whatWeDo={get(model, 'fields.whatWeDo.simpleFragments', {})}
+                selectedClients={get(
+                  model,
+                  'fields.selectedClients.simpleFragments',
+                  {}
+                )}
+                technologyStack={get(
+                  model,
+                  'fields.technologyStack.simpleFragments',
+                  {}
+                )}
+                software={get(model, 'fields.software.simpleFragments', {})}
+                collaborators={get(
+                  model,
+                  'fields.collaborators.simpleFragments',
+                  {}
+                )}
+              />
+            </div>
+            <div className="col-8 flex order-first md:order-last">
+              <IntroSectionParagraph
+                introParagraph={get(model, 'fields.introParagraph')}
+              />
+            </div>
+          </div>
+          <div aria-hidden={shouldShowOverlay}>
+            <WorkSection selectedWorks={get(model, 'fields.selectedWorks', [])} />
+          </div>
+          <div aria-hidden={shouldShowOverlay}>
+            <Gallery
+              images={get(model, 'fields.gallery', {})}
+              settingExpectations={get(model, 'fields.settingExpectations')}
+              recentArticles={get(
+                model,
+                'fields.recentArticles.simpleFragments',
+                {}
+              )}
+              socialMedia={get(model, 'fields.socialMedia.simpleFragments', {})}
+              openSourceProjects={get(
+                model,
+                'fields.openSourceProjects.simpleFragments',
+                {}
+              )}
+              availablePositions={get(
+                model,
+                'fields.availablePositions.simpleFragments',
+                {}
+              )}
+            />
+          </div>
+          <Footer hidden={shouldShowOverlay} />
+        </div>
+      )}
+    </Fragment>
+  );
 }
 
 export const getStaticProps = async () => {

--- a/styles/components/Overlay.scss
+++ b/styles/components/Overlay.scss
@@ -4,10 +4,11 @@
 
   &--active {
     pointer-events: auto;
+    opacity: 1;
   }
 
   &__navigation {
-    @include media("sm-down") {
+    @include media('sm-down') {
       position: absolute;
       bottom: 0;
       left: 0;
@@ -16,10 +17,10 @@
 
   &__social-media-list {
     a {
-      color: color("white");
+      color: color('white');
     }
 
-    @include media("sm-down") {
+    @include media('sm-down') {
       position: fixed;
       bottom: 0;
       left: 0;
@@ -27,7 +28,7 @@
   }
 
   &__footer {
-    @include media("md-up") {
+    @include media('md-up') {
       left: 0;
     }
   }
@@ -40,7 +41,7 @@
     letter-spacing: -5;
 
     > p {
-      @include media("md-up") {
+      @include media('md-up') {
         &::before {
           content: '';
           display: block;
@@ -48,23 +49,23 @@
         }
       }
 
-      @include media("lg-up") {
+      @include media('lg-up') {
         &::before {
           content: '';
           display: block;
-          margin: -0.50rem 0;
+          margin: -0.5rem 0;
         }
       }
     }
 
-    @include media("md-up") {
+    @include media('md-up') {
       font-size: 2.5rem;
       line-height: 3rem;
     }
 
-    @include media("lg-up") {
+    @include media('lg-up') {
       font-size: 3.125rem;
-      line-height: 3.75rem; 
+      line-height: 3.75rem;
     }
   }
 }

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -16,3 +16,7 @@
   background-color: color('gray-darkest');
   overflow: hidden;
 }
+
+html {
+  transition: background-color 3500ms cubic-bezier(0.79, 0.1, 0.56, 0.93);
+}


### PR DESCRIPTION
### Description:
- Right now, "Night Mode" is a modal, but all of the JS runs underneath it. It doesn't make sense to load anything if Night Mode is enabled, so let's only render nightmode if it is night in the user's local time
- Keep in mind that Next.js won't know the user's local browser time, so this "switch" will have to happen on the client side