### PR TITLE
Add padding between image and caption text

### DIFF
--- a/components/BlockViewMore.js
+++ b/components/BlockViewMore.js
@@ -49,7 +49,7 @@ const BlockViewMore = props => {
                 >
                   <div className="flex flex-col">
                     <Image
-                      className="h100 w100 hauto fit-cover pb1"
+                      className="h100 w100 hauto fit-cover"
                       alt={linkOneImage.description}
                       src={linkOneImage.url}
                       width={linkOneImage.width}
@@ -57,11 +57,13 @@ const BlockViewMore = props => {
                       sizes={selectedSizes}
                     />
                     {linkOneImageCaption && (
-                      <p className="image-caption small color-gray-darkest pb_5">
+                      <p className="image-caption small color-gray-darkest pt1 pb_5">
                         {linkOneImageCaption}
                       </p>
                     )}
+                    <p className="pt1">
                     → {linkOneText}
+                    </p>
                   </div>
                 </a>
               </Link>
@@ -80,7 +82,7 @@ const BlockViewMore = props => {
                 >
                   <div className="flex flex-col">
                     <Image
-                      className="right-side h100 w100 hauto fit-cover pb1"
+                      className="right-side h100 w100 hauto fit-cover"
                       alt={linkTwoImage.description}
                       src={linkTwoImage.url}
                       width={linkTwoImage.width}
@@ -88,11 +90,13 @@ const BlockViewMore = props => {
                       sizes={selectedSizes}
                     />
                     {linkTwoImageCaption && (
-                      <p className="image-caption small color-gray-darkest pb_5">
+                      <p className="image-caption small color-gray-darkest pt1 pb_5">
                         {linkTwoImageCaption}
                       </p>
                     )}
+                    <p className="pt1">
                     → {linkTwoText}
+                    </p>
                   </div>
                 </a>
               </Link>

--- a/components/CaseStudyTopNav.js
+++ b/components/CaseStudyTopNav.js
@@ -61,7 +61,7 @@ class CaseStudyTopNav extends Component {
         </div>
         <div
           className={cx(
-            'CaseStudyTopNav events-none none opacity-0 l0 r0 t0 p1',
+            'CaseStudyTopNav events-none none opacity-0 l0 r0 t0 p1 nav-z-index',
             {
               'CaseStudyTopNav--active opacity-1 events-all': showCaseStudyTopNav
             }

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -20,3 +20,7 @@
 html {
   transition: background-color 3500ms cubic-bezier(0.79, 0.1, 0.56, 0.93);
 }
+
+.nav-z-index {
+  z-index: 800;
+}


### PR DESCRIPTION
Description:
- Add padding between image and image caption
- Add z-index to case study top nav to make "back to Sanctuary" button not go under content

Preview: 
https://sanctu-dot-com-4p9wwsyd2-sanctucompu.vercel.app/capabilities