### PR TITLE
QA: refactor image gallery

### DIFF
--- a/components/Gallery.js
+++ b/components/Gallery.js
@@ -16,8 +16,8 @@ class Gallery extends PureComponent {
     );
   };
   renderGalleryRow = (imageGroup, index, imageMatrix) => {
-    const imageOne = flattenImageData(imageGroup[0])
-    const imageTwo = flattenImageData(imageGroup[1])
+    const imageOne = flattenImageData(imageGroup[0]);
+    const imageTwo = flattenImageData(imageGroup[1]);
     const imageOneUrl = imageOne.url;
     const imageTwoUrl = imageTwo.url;
 
@@ -27,14 +27,14 @@ class Gallery extends PureComponent {
           className="flex flex-col md:flex-row col-8 pb_5 md:pb1"
           key={index}
         >
-          <div className="col-8 md:col-4 pr_25 md:pr_5">
+          <div className="col-8 md:col-4">
             <Image
               className="col-4 md:col-8"
               alt={imageOne.description}
               src={imageOneUrl}
               width={imageOne.width}
               height={imageOne.height}
-              sizes='50vw'
+              sizes="50vw"
             />
             <StudioDetailsSection
               recentArticles={get(this, 'props.recentArticles', {})}
@@ -43,7 +43,7 @@ class Gallery extends PureComponent {
               availablePositions={get(this, 'props.availablePositions', {})}
             />
           </div>
-          <div className="col-8 md:col-4 p_25 md:p_5">
+          <div className="col-8 md:col-4 md:ml1 md:mt1 md:mb1">
             <div className="sticky">
               <Markdown
                 src={get(this, 'props.settingExpectations')}
@@ -57,23 +57,23 @@ class Gallery extends PureComponent {
 
     return (
       <div className="flex col-8 pb_5 md:pb1 items-end" key={index}>
-        <div className="block col-4 pr_25 md:pr_5">
+        <div className="block col-4">
           {index === 0 ? this.renderAttribution() : null}
           <Image
             src={imageOneUrl}
             width={imageOne.width}
             height={imageOne.height}
             alt={imageOne.description}
-            sizes='50vw'
+            sizes="50vw"
           />
         </div>
-        <div className="block col-4 pl_25 md:pl_5">
+        <div className="block col-4 ml_5 md:ml1">
           <Image
             src={imageTwoUrl}
             width={imageTwo.width}
             height={imageTwo.height}
             alt={imageTwo.description}
-            sizes='50vw'
+            sizes="50vw"
           />
         </div>
       </div>
@@ -106,11 +106,11 @@ Gallery.propTypes = {
     PropTypes.shape({
       fields: PropTypes.shape({
         file: PropTypes.shape({
-          url: PropTypes.string
-        })
-      })
+          url: PropTypes.string,
+        }),
+      }),
     })
-  )
+  ),
 };
 
 export default Gallery;

--- a/components/Gallery.js
+++ b/components/Gallery.js
@@ -92,7 +92,7 @@ class Gallery extends PureComponent {
     );
 
     return (
-      <div className="col-8 p1 flex flex-wrap">
+      <div className="col-8 p1 flex flex-wrap overflow-hidden">
         {imageMatrix.map((imageGroup, index) =>
           this.renderGalleryRow(imageGroup, index, imageMatrix)
         )}

--- a/components/Overlay.js
+++ b/components/Overlay.js
@@ -11,9 +11,9 @@ const Overlay = ({ socialMedia, shouldShowOverlay }) => {
     <div
       aria-hidden={!shouldShowOverlay}
       className={cx(
-        'Overlay fixed vw100 vh100 flex flex-col overflow-hidden col-12 bg-color-gray-darkest color-white z3 opacity-0',
+        'Overlay fixed vh100 flex flex-col overflow-hidden col-12 bg-color-gray-darkest color-white z3 opacity-0',
         {
-          'Overlay--active': !!shouldShowOverlay
+          'Overlay--active': !!shouldShowOverlay,
         }
       )}
     >
@@ -38,8 +38,8 @@ const Overlay = ({ socialMedia, shouldShowOverlay }) => {
           </div>
           <div className="Overlay__paragraph col-12 md:col-4">
             <p>
-              Website hours are Monday to Friday 7 AM - 7 PM (in your browser&apos;s
-              local time).
+              Website hours are Monday to Friday 7 AM - 7 PM (in your
+              browser&apos;s local time).
             </p>
           </div>
         </div>

--- a/components/Work.js
+++ b/components/Work.js
@@ -11,41 +11,45 @@ import { Image } from 'components/base';
 import get from 'utils/get';
 import flattenImageData from 'utils/flattenImageData';
 
-const PLAY_VIDEO = "(Play)";
-const PAUSE_VIDEO = "(Pause)"; 
+const PLAY_VIDEO = '(Play)';
+const PAUSE_VIDEO = '(Pause)';
 
 const Work = ({ work, width = '100vw' }) => {
   const [videoStatus, setVideoStatus] = useState(PLAY_VIDEO);
   const videoRef = useRef(null);
-  const buttonRef = useRef(null); 
+  const buttonRef = useRef(null);
 
   useEffect(() => {
-    if (videoStatus == PLAY_VIDEO) { 
-      videoRef.current?.play(); 
+    if (videoStatus == PLAY_VIDEO) {
+      videoRef.current?.play();
 
       const button = buttonRef.current;
       if (button) {
         button.textContent = PAUSE_VIDEO;
-        button.ariaLabel = `pause video for ${title}`
+        button.ariaLabel = `pause video for ${title}`;
       }
-    } else { 
+    } else {
       videoRef.current?.pause();
 
       const button = buttonRef.current;
-      if(button) {
+      if (button) {
         button.textContent = PLAY_VIDEO;
-        button.ariaLabel = `play video for ${title}`
+        button.ariaLabel = `play video for ${title}`;
       }
     }
-  }, [videoStatus])
+  }, [videoStatus]);
 
   const workIsPlaceholder = !work?.fields?.name;
 
-  if (!work || workIsPlaceholder) { 
-    return null; 
+  if (!work || workIsPlaceholder) {
+    return null;
   }
 
-  const workIsImage = get(work, 'fields.asset.fields.file.contentType', '').startsWith("image/");  
+  const workIsImage = get(
+    work,
+    'fields.asset.fields.file.contentType',
+    ''
+  ).startsWith('image/');
   const workImage = flattenImageData(get(work, 'fields.asset', {}));
   const title = get(work, 'fields.title', '');
   const caseStudySlug = get(work, 'fields.caseStudySlug', '');
@@ -54,73 +58,81 @@ const Work = ({ work, width = '100vw' }) => {
   const id = get(work, 'sys.id', '');
 
   return (
-   <>
-    <div className={`WorkSectionAsGallery__work-hover-overlay ${workIsImage ? 'WorkSectionAsGallery__work-hover-overlay--for-image' : 'WorkSectionAsGallery__work-hover-overlay--for-video'} flex justify-between items-end color-white absolute`}>
-      <div className="WorkSectionAsGallery__work-hover-overlay--info flex flex-col justify-evenly mb_5 ml_5">
-        <div className="WorkSectionAsGallery__work-hover-overlay--title">{title}</div>
-        {caseStudySlug ? 
-          <Link
-            href={caseStudySlug}
-          >
-            <a
-              className="decoration-none color-white"
-              aria-label={`read the case study for ${title}`}
-              rel="noopener noreferrer"
-            >
-            (read case study)
-            </a>
-          </Link> : 
-          <Link
-            href={link}
-          >
-            <a
-              className="decoration-none color-white"
-              aria-label={`visit the site for ${title}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-            → visit the site 
-            </a>
-          </Link>
-        }
-      </div>
-      {!workIsImage &&
-        <button 
-          className="WorkSectionAsGallery__work-hover-overlay--video-button"
-          aria-label={`pause video for ${title}`}
-          ref={buttonRef}
-          onClick={() => {
-            videoStatus === PAUSE_VIDEO ? setVideoStatus(PLAY_VIDEO) : setVideoStatus(PAUSE_VIDEO)
-          }}
-        >
-          (Pause)
-        </button>
-      }
-    </div>
-    {workIsImage ? 
-      <Image
-        alt={workImage.alt}
-        src={workImage.url}
-        width={workImage.width}
-        height={workImage.height}
-        sizes={width}
-      />  :
-      <video
-        id={id}
-        key={id}
-        className="w100 h100"
-        autoPlay
-        loop
-        muted
-        playsInline
-        ref={videoRef}
+    <>
+      <div
+        className={`WorkSectionAsGallery__work-hover-overlay ${
+          workIsImage
+            ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
+            : 'WorkSectionAsGallery__work-hover-overlay--for-video'
+        } flex justify-between items-end color-white absolute`}
       >
-        <source src={src}></source>
-      </video>
-    }
+        <div className="WorkSectionAsGallery__work-hover-overlay--info flex flex-col justify-evenly mb_5 ml_5">
+          <div className="WorkSectionAsGallery__work-hover-overlay--title">
+            {title}
+          </div>
+          {caseStudySlug ? (
+            <Link href={caseStudySlug}>
+              <a
+                className="decoration-none color-white"
+                aria-label={`read the case study for ${title}`}
+                rel="noopener noreferrer"
+              >
+                (read case study)
+              </a>
+            </Link>
+          ) : (
+            <Link href={link}>
+              <a
+                className="decoration-none color-white"
+                aria-label={`visit the site for ${title}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                → visit the site
+              </a>
+            </Link>
+          )}
+        </div>
+        {!workIsImage && (
+          <button
+            className="WorkSectionAsGallery__work-hover-overlay--video-button"
+            aria-label={`pause video for ${title}`}
+            ref={buttonRef}
+            onClick={() => {
+              videoStatus === PAUSE_VIDEO
+                ? setVideoStatus(PLAY_VIDEO)
+                : setVideoStatus(PAUSE_VIDEO);
+            }}
+          >
+            (Pause)
+          </button>
+        )}
+      </div>
+      {workIsImage ? (
+        <Image
+          alt={workImage.alt}
+          src={workImage.url}
+          width={workImage.width}
+          height={workImage.height}
+          sizes={width}
+        />
+      ) : (
+        <video
+          id={id}
+          key={id}
+          className="block w100 h100"
+          autoPlay
+          loop
+          muted
+          playsInline
+          ref={videoRef}
+        >
+          <source src={src}></source>
+        </video>
+      )}
     </>
- );
-}
+  );
+};
 
 Work.propTypes = {
   work: PropTypes.shape({
@@ -132,10 +144,9 @@ Work.propTypes = {
       linkLabel: PropTypes.string,
       stack: SimpleFragment,
       collaborators: SimpleFragment,
-      video: ContentfulMedia
-    })
-  })
-}
+      video: ContentfulMedia,
+    }),
+  }),
+};
 
-export default Work; 
-
+export default Work;

--- a/components/Work.js
+++ b/components/Work.js
@@ -60,13 +60,13 @@ const Work = ({ work, width = '100vw' }) => {
   return (
     <>
       <div
-        className={`WorkSectionAsGallery__work-hover-overlay ${
+        className={`WorkSectionAsGallery__work-hover-overlay lg:p1_5 md:p1 p_625 ${
           workIsImage
             ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
             : 'WorkSectionAsGallery__work-hover-overlay--for-video'
         } flex justify-between items-end color-white absolute`}
       >
-        <div className="WorkSectionAsGallery__work-hover-overlay--info flex flex-col justify-evenly mb_5 ml_5">
+        <div className="flex flex-col">
           <div className="WorkSectionAsGallery__work-hover-overlay--title">
             {title}
           </div>

--- a/components/Work.js
+++ b/components/Work.js
@@ -60,7 +60,7 @@ const Work = ({ work, width = '100vw' }) => {
   return (
     <>
       <div
-        className={`WorkSectionAsGallery__work-hover-overlay lg:p1_5 md:p1 p_625 ${
+        className={`WorkSectionAsGallery__work-hover-overlay md:p1 p_625 ${
           workIsImage
             ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
             : 'WorkSectionAsGallery__work-hover-overlay--for-video'

--- a/components/WorkSectionAsGallery.js
+++ b/components/WorkSectionAsGallery.js
@@ -28,7 +28,7 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
           <div className="block col-8 mb_5 md:mb1 relative">
             <Work work={works[0]} />
           </div>
-          <div className="flex col-8 pb_5 md:pb1 items-start">
+          <div className="flex col-8 pb_5 md:pb1 items-end">
             <div className="block col-4">
               <div className="relative">
                 <Work work={works[1]} width="50vw" />

--- a/components/WorkSectionAsGallery.js
+++ b/components/WorkSectionAsGallery.js
@@ -22,19 +22,19 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
   const works = get(assetBlock, 'fields.works', []);
 
   return (
-    <div className="flex-col pt1 pl1 pr1">
+    <div className="flex-col pt_5 md:pt1 pr1 pl1">
       {displayFirstAssetAsFullWidth && (
         <>
           <div className="block col-8 mb_5 md:mb1 relative">
             <Work work={works[0]} />
           </div>
           <div className="flex col-8 pb_5 md:pb1 items-start">
-            <div className="block col-4 pr_25 md:pr_5">
+            <div className="block col-4">
               <div className="relative">
                 <Work work={works[1]} width="50vw" />
               </div>
             </div>
-            <div className="block col-4 pl_25 md:pl_5">
+            <div className="block col-4 ml_5 md:ml1">
               <div className="relative">
                 <Work work={works[2]} width="50vw" />
               </div>
@@ -45,12 +45,12 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
       {!displayFirstAssetAsFullWidth && (
         <>
           <div className="flex col-8 pb_5 md:pb1 items-end">
-            <div className="block col-4 pr_25 md:pr_5">
+            <div className="block col-4">
               <div className="relative">
                 <Work work={works[0]} width="50vw" />
               </div>
             </div>
-            <div className="block col-4 pl_25 md:pl_5">
+            <div className="block col-4 ml_5 md:ml1">
               <div className="relative">
                 <Work work={works[1]} width="50vw" />
               </div>

--- a/components/WorkSectionAsGallery.js
+++ b/components/WorkSectionAsGallery.js
@@ -9,22 +9,26 @@ import Work from 'components/Work';
 
 import get from 'utils/get';
 
-const WorkGalleryAssetBlock = ({assetBlock}) => {
+const WorkGalleryAssetBlock = ({ assetBlock }) => {
   if (!assetBlock) {
-    return null; 
+    return null;
   }
 
-  const displayFirstAssetAsFullWidth = get(assetBlock, 'fields.displayFirstAssetAsFullWidth', true);
+  const displayFirstAssetAsFullWidth = get(
+    assetBlock,
+    'fields.displayFirstAssetAsFullWidth',
+    true
+  );
   const works = get(assetBlock, 'fields.works', []);
 
   return (
-    <div className="flex-col">
-      {displayFirstAssetAsFullWidth && 
+    <div className="flex-col pt1 pl1 pr1">
+      {displayFirstAssetAsFullWidth && (
         <>
-          <div className="block col-8 relative">
-            <Work work={works[0]}/>
+          <div className="block col-8 mb_5 md:mb1 relative">
+            <Work work={works[0]} />
           </div>
-          <div className="flex col-8 pb_5 md:pb1 items-end">
+          <div className="flex col-8 pb_5 md:pb1 items-start">
             <div className="block col-4 pr_25 md:pr_5">
               <div className="relative">
                 <Work work={works[1]} width="50vw" />
@@ -37,8 +41,8 @@ const WorkGalleryAssetBlock = ({assetBlock}) => {
             </div>
           </div>
         </>
-      }
-      {!displayFirstAssetAsFullWidth && 
+      )}
+      {!displayFirstAssetAsFullWidth && (
         <>
           <div className="flex col-8 pb_5 md:pb1 items-end">
             <div className="block col-4 pr_25 md:pr_5">
@@ -53,15 +57,15 @@ const WorkGalleryAssetBlock = ({assetBlock}) => {
             </div>
           </div>
           <div className="block col-8 relative">
-            <Work work={works[2]}/>
+            <Work work={works[2]} />
           </div>
         </>
-      }
+      )}
     </div>
   );
-}
+};
 
-const WorkGalleryTextBlock = ({textBlock}) => {
+const WorkGalleryTextBlock = ({ textBlock }) => {
   if (!textBlock) {
     return null;
   }
@@ -69,39 +73,50 @@ const WorkGalleryTextBlock = ({textBlock}) => {
   const text = get(textBlock, 'fields.text', '');
   return (
     <div>
-      {text &&
+      {text && (
         <Markdown
           className="WorkSectionAsGallery__work-gallery-text px1_25 py5 md:p13 Markdown--medium"
           src={text}
         />
-      }
+      )}
     </div>
   );
 };
 
 const WorkSectionAsGallery = (props) => {
-  const fields = get(props, 'workGallery.fields', {}); 
+  const fields = get(props, 'workGallery.fields', {});
   const workGalleryAssetBlocks = get(fields, 'workGalleryAssetBlocks', []);
   const workGalleryTextBlocks = get(fields, 'workGalleryTextBlocks', []);
   const renderAssetBlocksFirst = get(fields, 'renderAssetBlocksFirst', true);
 
   // In order to render all elements of both arrays, we need to loop an amount equal to the longer of the two arrays.
-  const numberOfBlocksToLoopThrough = workGalleryAssetBlocks.length > workGalleryTextBlocks.length ? [...Array(workGalleryAssetBlocks.length).keys()] : [...Array(workGalleryTextBlocks.length).keys()]; 
-  
+  const numberOfBlocksToLoopThrough =
+    workGalleryAssetBlocks.length > workGalleryTextBlocks.length
+      ? [...Array(workGalleryAssetBlocks.length).keys()]
+      : [...Array(workGalleryTextBlocks.length).keys()];
+
   return (
     <div className="WorkSectionAsGallery mt2">
       {numberOfBlocksToLoopThrough.map((index) => {
         return (
           <div key={index}>
-            {renderAssetBlocksFirst && <WorkGalleryAssetBlock assetBlock={workGalleryAssetBlocks[index]}/>}
-            <WorkGalleryTextBlock textBlock={workGalleryTextBlocks[index]}/>
-            {!renderAssetBlocksFirst && <WorkGalleryAssetBlock assetBlock={workGalleryAssetBlocks[index]}/>}
+            {renderAssetBlocksFirst && (
+              <WorkGalleryAssetBlock
+                assetBlock={workGalleryAssetBlocks[index]}
+              />
+            )}
+            <WorkGalleryTextBlock textBlock={workGalleryTextBlocks[index]} />
+            {!renderAssetBlocksFirst && (
+              <WorkGalleryAssetBlock
+                assetBlock={workGalleryAssetBlocks[index]}
+              />
+            )}
           </div>
         );
       })}
     </div>
   );
-}
+};
 
 const WorkPropType = PropTypes.shape({
   fields: PropTypes.shape({
@@ -112,30 +127,29 @@ const WorkPropType = PropTypes.shape({
     linkLabel: PropTypes.string,
     stack: SimpleFragment,
     collaborators: SimpleFragment,
-    video: ContentfulMedia
-  })
-}); 
+    video: ContentfulMedia,
+  }),
+});
 
 const WorkGalleryTextBlockPropType = PropTypes.shape({
-  text: PropTypes.string
-})
+  text: PropTypes.string,
+});
 
 const WorkGalleryAssetBlockPropType = PropTypes.shape({
-  title: PropTypes.string, 
+  title: PropTypes.string,
   works: PropTypes.arrayOf(WorkPropType),
-  displayFirstAssetAsFullWidth: PropTypes.bool
-})
+  displayFirstAssetAsFullWidth: PropTypes.bool,
+});
 
 WorkSectionAsGallery.propTypes = {
   workGallery: PropTypes.shape({
     fields: PropTypes.shape({
-      title: PropTypes.string, 
+      title: PropTypes.string,
       workGalleryAssetBlocks: PropTypes.arrayOf(WorkGalleryAssetBlockPropType),
       workGalleryTextBlocks: PropTypes.arrayOf(WorkGalleryTextBlockPropType),
-      renderAssetBlocksFirst: PropTypes.bool
-    })
-  })
-}
+      renderAssetBlocksFirst: PropTypes.bool,
+    }),
+  }),
+};
 
 export default WorkSectionAsGallery;
-

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -25,10 +25,6 @@
       line-height: 1.5rem;
     }
 
-    @include media('lg-up') {
-      line-height: 2rem;
-    }
-
     &--title {
       font-weight: bold;
     }

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -1,44 +1,44 @@
-.WorkSectionAsGallery{
-    &__work-hover-overlay {
-        &--for-image {
-            width: 100%; 
-            height: 100%;
-        }
-
-        &--for-video {
-            width: 100%; 
-            height: 99.5%; 
-        }
-
-        opacity: 1;
-
-        @include media('lg-up') {
-            opacity: 0;
-        }
-        background: linear-gradient(to bottom, transparent 0%, black 200%);
-
-        font-family: $sans-serif-stack;
-        font-size: .75rem; 
-        &--title {
-            font-weight: bold; 
-        }
-        
-        z-index: 99; 
-
-        &--info {
-            height: 3rem; 
-        }
-
-        &--video-button {
-            all: unset; 
-            cursor: pointer; 
-            height: 2rem; 
-            margin: 0rem .5rem .5rem 0rem;
-        }
+.WorkSectionAsGallery {
+  &__work-hover-overlay {
+    &--for-image {
+      width: 100%;
+      height: 100%;
     }
 
-    &__work-hover-overlay:hover {
-        opacity: 1; 
-        background: linear-gradient(to bottom, transparent 0%, black 200%);
+    &--for-video {
+      width: 100%;
+      height: 100%;
     }
+
+    opacity: 1;
+
+    @include media('lg-up') {
+      opacity: 0;
+    }
+    background: linear-gradient(to bottom, transparent 0%, black 200%);
+
+    font-family: $sans-serif-stack;
+    font-size: 0.75rem;
+    &--title {
+      font-weight: bold;
+    }
+
+    z-index: 99;
+
+    &--info {
+      height: 3rem;
+    }
+
+    &--video-button {
+      all: unset;
+      cursor: pointer;
+      height: 2rem;
+      margin: 0rem 0.5rem 0.5rem 0rem;
+    }
+  }
+
+  &__work-hover-overlay:hover {
+    opacity: 1;
+    background: linear-gradient(to bottom, transparent 0%, black 200%);
+  }
 }

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -17,23 +17,27 @@
     }
     background: linear-gradient(to bottom, transparent 0%, black 200%);
 
-    font-family: $sans-serif-stack;
-    font-size: 0.75rem;
+    @extend .tiny;
+    line-height: 1.125rem;
+    margin: 0;
+
+    @include media('md') {
+      line-height: 1.5rem;
+    }
+
+    @include media('lg-up') {
+      line-height: 2rem;
+    }
+
     &--title {
       font-weight: bold;
     }
 
     z-index: 99;
 
-    &--info {
-      height: 3rem;
-    }
-
     &--video-button {
       all: unset;
       cursor: pointer;
-      height: 2rem;
-      margin: 0rem 0.5rem 0.5rem 0rem;
     }
   }
 

--- a/styles/config.scss
+++ b/styles/config.scss
@@ -2,7 +2,7 @@ $colors: (
   'black': #000000,
   'gray-darkest': #141414,
   'gray': #757575,
-  'white': #ffffff
+  'white': #ffffff,
 );
 
 $breakpoints: (
@@ -11,10 +11,11 @@ $breakpoints: (
   'md': 832px,
   'lg': 1024px,
   'xl': 1152px,
-  'xxl': 1280px
+  'xxl': 1280px,
 );
 
-$spacing-units: 0rem, 0.25rem, 0.5rem, 0.75rem, 1rem, 1.25rem, 1.5rem, 2rem,
-  3rem, 4rem, 5rem, 6rem, 7rem, 8rem, 10rem, 11rem, 12rem, 13rem, 14rem, 15rem;
+$spacing-units: 0rem, 0.25rem, 0.5rem, 0.625rem, 0.75rem, 1rem, 1.25rem, 1.5rem,
+  2rem, 3rem, 4rem, 5rem, 6rem, 7rem, 8rem, 10rem, 11rem, 12rem, 13rem, 14rem,
+  15rem;
 
 $grid-columns: 8;

--- a/styles/type.scss
+++ b/styles/type.scss
@@ -23,7 +23,7 @@ $p-xl-line-height: 3.6rem;
     line-height: $p-md-line-height;
   }
 
-  @include media('lg-up') {
+  @include media('xl') {
     font-size: 3rem;
     line-height: $p-xl-line-height;
   }
@@ -42,19 +42,13 @@ $p-xl-line-height: 3.6rem;
   font-weight: 400;
 
   margin: 0 2px;
-  font-size: 12px;
+  font-size: 0.75rem;
   letter-spacing: 0.4px;
 
   @include media('md') {
     margin: 0 2px;
     font-size: 0.9375rem;
     letter-spacing: 0.4px;
-  }
-
-  @include media('lg-up') {
-    margin: 0 2px;
-    font-size: 1.25rem;
-    letter-spacing: 0.5px;
   }
 }
 

--- a/styles/type.scss
+++ b/styles/type.scss
@@ -1,9 +1,9 @@
 $serif-stack: 'Austin News Deck Web', serif;
 $sans-serif-stack: 'Atlas Grotesk Web', sans-serif;
 
-$p-line-height: 2.1rem;
-$p-md-line-height: 2.64rem;
-$p-xl-line-height: 3rem;
+$p-line-height: 1.8rem;
+$p-md-line-height: 2.7rem;
+$p-xl-line-height: 3.6rem;
 
 .header {
   font-family: $serif-stack;
@@ -15,17 +15,16 @@ $p-xl-line-height: 3rem;
 .paragraph {
   font-family: $serif-stack;
   font-weight: 200;
-  font-size: 1.65rem;
+  font-size: 1.5rem;
   line-height: $p-line-height;
-  letter-spacing: -5;
 
   @include media('md') {
-    font-size: 2.2rem;
+    font-size: 2.25rem;
     line-height: $p-md-line-height;
   }
 
-  @include media('xl') {
-    font-size: 2.5rem;
+  @include media('lg-up') {
+    font-size: 3rem;
     line-height: $p-xl-line-height;
   }
 }
@@ -43,18 +42,18 @@ $p-xl-line-height: 3rem;
   font-weight: 400;
 
   margin: 0 2px;
-  font-size: 8px;
+  font-size: 12px;
   letter-spacing: 0.4px;
 
   @include media('md') {
     margin: 0 2px;
-    font-size: 10px;
+    font-size: 0.9375rem;
     letter-spacing: 0.4px;
   }
 
-  @include media('xl') {
+  @include media('lg-up') {
     margin: 0 2px;
-    font-size: 11px;
+    font-size: 1.25rem;
     letter-spacing: 0.5px;
   }
 }


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->

- separate [the issue](https://www.notion.so/garden3d/The-new-blocks-do-not-use-the-same-design-system-as-the-existing-photo-gallery-493dea3372f04a73afacb73948f2a2fc#1ac728f203d9429e98aa164a3c1d5777) which needs to be handled on the editor side from other dev related issues : this was cause because the image has white space in it
- fix the inconsistent spacing between grid items in Work Gallery by changing the padding/margin values following the latest design([Figma link](https://www.figma.com/file/M6zHKnDZ7ALV5pZxPvVSHZ/sanctuary.computer-refresh?node-id=59%3A347&t=0eCc3t2nOWynAjRQ-1))
- fix the spacing between Work Gallery and left/right side of entire main page to be consistent with other modules'
- update the type system based on the design to match the spacing for the grid item label and make font size of it responsive
- the change request for hover container style(light/dark) will be handled in issue #174 

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
- Closes #171 
- QA item from Notion([link](https://www.notion.so/garden3d/The-new-blocks-do-not-use-the-same-design-system-as-the-existing-photo-gallery-493dea3372f04a73afacb73948f2a2fc))

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
Tested on desktop and mobile browser(Chrome/Safari) via [this preview](https://sanctu-dot-l40qnryus-sanctucompu.vercel.app/)

### Applicable screenshots

<!--- When appropriate, upload screenshots. -->
https://www.loom.com/share/7fca46ff8a2d49eea7cb35afcf760f22


