### PR TITLE
QA: make whole work item area clickable

### DIFF
--- a/components/Work.js
+++ b/components/Work.js
@@ -11,41 +11,45 @@ import { Image } from 'components/base';
 import get from 'utils/get';
 import flattenImageData from 'utils/flattenImageData';
 
-const PLAY_VIDEO = "(Play)";
-const PAUSE_VIDEO = "(Pause)"; 
+const PLAY_VIDEO = '(Play)';
+const PAUSE_VIDEO = '(Pause)';
 
 const Work = ({ work, width = '100vw' }) => {
   const [videoStatus, setVideoStatus] = useState(PLAY_VIDEO);
   const videoRef = useRef(null);
-  const buttonRef = useRef(null); 
+  const buttonRef = useRef(null);
 
   useEffect(() => {
-    if (videoStatus == PLAY_VIDEO) { 
-      videoRef.current?.play(); 
+    if (videoStatus == PLAY_VIDEO) {
+      videoRef.current?.play();
 
       const button = buttonRef.current;
       if (button) {
         button.textContent = PAUSE_VIDEO;
-        button.ariaLabel = `pause video for ${title}`
+        button.ariaLabel = `pause video for ${title}`;
       }
-    } else { 
+    } else {
       videoRef.current?.pause();
 
       const button = buttonRef.current;
-      if(button) {
+      if (button) {
         button.textContent = PLAY_VIDEO;
-        button.ariaLabel = `play video for ${title}`
+        button.ariaLabel = `play video for ${title}`;
       }
     }
-  }, [videoStatus])
+  }, [videoStatus]);
 
   const workIsPlaceholder = !work?.fields?.name;
 
-  if (!work || workIsPlaceholder) { 
-    return null; 
+  if (!work || workIsPlaceholder) {
+    return null;
   }
 
-  const workIsImage = get(work, 'fields.asset.fields.file.contentType', '').startsWith("image/");  
+  const workIsImage = get(
+    work,
+    'fields.asset.fields.file.contentType',
+    ''
+  ).startsWith('image/');
   const workImage = flattenImageData(get(work, 'fields.asset', {}));
   const title = get(work, 'fields.title', '');
   const caseStudySlug = get(work, 'fields.caseStudySlug', '');
@@ -54,73 +58,75 @@ const Work = ({ work, width = '100vw' }) => {
   const id = get(work, 'sys.id', '');
 
   return (
-   <>
-    <div className={`WorkSectionAsGallery__work-hover-overlay ${workIsImage ? 'WorkSectionAsGallery__work-hover-overlay--for-image' : 'WorkSectionAsGallery__work-hover-overlay--for-video'} flex justify-between items-end color-white absolute`}>
-      <div className="WorkSectionAsGallery__work-hover-overlay--info flex flex-col justify-evenly mb_5 ml_5">
-        <div className="WorkSectionAsGallery__work-hover-overlay--title">{title}</div>
-        {caseStudySlug ? 
-          <Link
-            href={caseStudySlug}
-          >
-            <a
-              className="decoration-none color-white"
-              aria-label={`read the case study for ${title}`}
-              rel="noopener noreferrer"
-            >
-            (read case study)
-            </a>
-          </Link> : 
-          <Link
-            href={link}
-          >
-            <a
-              className="decoration-none color-white"
-              aria-label={`visit the site for ${title}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-            → visit the site 
-            </a>
-          </Link>
-        }
-      </div>
-      {!workIsImage &&
-        <button 
-          className="WorkSectionAsGallery__work-hover-overlay--video-button"
-          aria-label={`pause video for ${title}`}
-          ref={buttonRef}
-          onClick={() => {
-            videoStatus === PAUSE_VIDEO ? setVideoStatus(PLAY_VIDEO) : setVideoStatus(PAUSE_VIDEO)
-          }}
+    <>
+      <Link href={caseStudySlug || link}>
+        <a
+          aria-label={
+            caseStudySlug
+              ? `read the case study for ${title}`
+              : `visit the site for ${title}`
+          }
+          rel="noopener noreferrer"
+          target={caseStudySlug ? '_self' : '_blank'}
         >
-          (Pause)
-        </button>
-      }
-    </div>
-    {workIsImage ? 
-      <Image
-        alt={workImage.alt}
-        src={workImage.url}
-        width={workImage.width}
-        height={workImage.height}
-        sizes={width}
-      />  :
-      <video
-        id={id}
-        key={id}
-        className="w100 h100"
-        autoPlay
-        loop
-        muted
-        playsInline
-        ref={videoRef}
-      >
-        <source src={src}></source>
-      </video>
-    }
+          <div
+            className={`WorkSectionAsGallery__work-hover-overlay pointer ${
+              workIsImage
+                ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
+                : 'WorkSectionAsGallery__work-hover-overlay--for-video'
+            } flex justify-between items-end color-white absolute`}
+          >
+            <div className="WorkSectionAsGallery__work-hover-overlay--info flex flex-col justify-evenly mb_5 ml_5">
+              <div className="WorkSectionAsGallery__work-hover-overlay--title">
+                {title}
+              </div>
+              <div className="decoration-none color-white">
+                {caseStudySlug ? '(read case study)' : '→ visit the site'}
+              </div>
+            </div>
+            {!workIsImage && (
+              <button
+                className="WorkSectionAsGallery__work-hover-overlay--video-button"
+                aria-label={`pause video for ${title}`}
+                ref={buttonRef}
+                onClick={(e) => {
+                  e.preventDefault();
+                  videoStatus === PAUSE_VIDEO
+                    ? setVideoStatus(PLAY_VIDEO)
+                    : setVideoStatus(PAUSE_VIDEO);
+                }}
+              >
+                (Pause)
+              </button>
+            )}
+          </div>
+        </a>
+      </Link>
+      {workIsImage ? (
+        <Image
+          alt={workImage.alt}
+          src={workImage.url}
+          width={workImage.width}
+          height={workImage.height}
+          sizes={width}
+        />
+      ) : (
+        <video
+          id={id}
+          key={id}
+          className="w100 h100"
+          autoPlay
+          loop
+          muted
+          playsInline
+          ref={videoRef}
+        >
+          <source src={src}></source>
+        </video>
+      )}
     </>
- );
-}
+  );
+};
 
 Work.propTypes = {
   work: PropTypes.shape({
@@ -132,10 +138,9 @@ Work.propTypes = {
       linkLabel: PropTypes.string,
       stack: SimpleFragment,
       collaborators: SimpleFragment,
-      video: ContentfulMedia
-    })
-  })
-}
+      video: ContentfulMedia,
+    }),
+  }),
+};
 
-export default Work; 
-
+export default Work;


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- wrap entire hover container inside <Link> to make whole work item area clickable 
- make video control button work without propagating the click event to parent hover container 

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
- Closes #173 
- QA ticket from Notion([link](https://www.notion.so/garden3d/I-should-be-able-to-click-anywhere-on-the-hover-state-to-trigger-a-page-transition-and-see-cursor--e52af819a1ec4a2b8aaaf85f0708c215))

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
- tested with preview link on desktop and mobile Chrome and Safari

### Applicable screenshots

<!--- When appropriate, upload screenshots. -->
https://www.loom.com/share/a3945a91dd1340c79a12f9fda6a0e89f

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
