### PR TITLE
QA: black and white option for hover state on work gallery item

### DIFF
--- a/components/Work.js
+++ b/components/Work.js
@@ -84,9 +84,9 @@ const Work = ({ work, width = '100vw' }) => {
               } flex justify-between items-end absolute`,
               {
                 'WorkSectionAsGallery__work-hover-overlay--dark':
-                  hoveredStateTheme === 'light',
-                'WorkSectionAsGallery__work-hover-overlay--light':
                   hoveredStateTheme === 'dark',
+                'WorkSectionAsGallery__work-hover-overlay--light':
+                  hoveredStateTheme === 'light',
               }
             )}
           >

--- a/components/Work.js
+++ b/components/Work.js
@@ -10,6 +10,7 @@ import { Image } from 'components/base';
 
 import get from 'utils/get';
 import flattenImageData from 'utils/flattenImageData';
+import cx from 'classnames';
 
 const PLAY_VIDEO = '(Play)';
 const PAUSE_VIDEO = '(Pause)';
@@ -51,6 +52,7 @@ const Work = ({ work, width = '100vw' }) => {
     ''
   ).startsWith('image/');
   const workImage = flattenImageData(get(work, 'fields.asset', {}));
+  const hoveredStateTheme = get(work, 'fields.hoveredStateTheme', 'Dark').toLowerCase();
   const title = get(work, 'fields.title', '');
   const caseStudySlug = get(work, 'fields.caseStudySlug', '');
   const link = get(work, 'fields.link', '');

--- a/components/Work.js
+++ b/components/Work.js
@@ -52,7 +52,11 @@ const Work = ({ work, width = '100vw' }) => {
     ''
   ).startsWith('image/');
   const workImage = flattenImageData(get(work, 'fields.asset', {}));
-  const hoveredStateTheme = get(work, 'fields.hoveredStateTheme', 'Dark').toLowerCase();
+  const hoveredStateTheme = get(
+    work,
+    'fields.hoveredStateTheme',
+    'Dark'
+  ).toLowerCase();
   const title = get(work, 'fields.title', '');
   const caseStudySlug = get(work, 'fields.caseStudySlug', '');
   const link = get(work, 'fields.link', '');
@@ -72,17 +76,25 @@ const Work = ({ work, width = '100vw' }) => {
           target={caseStudySlug ? '_self' : '_blank'}
         >
           <div
-            className={`WorkSectionAsGallery__work-hover-overlay pointer ${
-              workIsImage
-                ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
-                : 'WorkSectionAsGallery__work-hover-overlay--for-video'
-            } flex justify-between items-end color-white absolute`}
+            className={cx(
+              `WorkSectionAsGallery__work-hover-overlay pointer ${
+                workIsImage
+                  ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
+                  : 'WorkSectionAsGallery__work-hover-overlay--for-video'
+              } flex justify-between items-end absolute`,
+              {
+                'WorkSectionAsGallery__work-hover-overlay--dark':
+                  hoveredStateTheme === 'dark',
+                'WorkSectionAsGallery__work-hover-overlay--light':
+                  hoveredStateTheme === 'light',
+              }
+            )}
           >
             <div className="WorkSectionAsGallery__work-hover-overlay--info flex flex-col justify-evenly mb_5 ml_5">
               <div className="WorkSectionAsGallery__work-hover-overlay--title">
                 {title}
               </div>
-              <div className="decoration-none color-white">
+              <div className="decoration-none">
                 {caseStudySlug ? '(read case study)' : '→ visit the site'}
               </div>
             </div>

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -1,44 +1,54 @@
-.WorkSectionAsGallery{
-    &__work-hover-overlay {
-        &--for-image {
-            width: 100%; 
-            height: 100%;
-        }
+.WorkSectionAsGallery {
+  &__work-hover-overlay {
+    &--for-image {
+      width: 100%;
+      height: 100%;
+    }
 
-        &--for-video {
-            width: 100%; 
-            height: 99.5%; 
-        }
+    &--for-video {
+      width: 100%;
+      height: 99.5%;
+    }
 
+    opacity: 1;
+
+    @include media('lg-up') {
+      opacity: 0;
+    }
+
+    &--light {
+      background: linear-gradient(to bottom, transparent 0%, white 200%);
+      color: black;
+      &:hover {
         opacity: 1;
-
-        @include media('lg-up') {
-            opacity: 0;
-        }
-        background: linear-gradient(to bottom, transparent 0%, black 200%);
-
-        font-family: $sans-serif-stack;
-        font-size: .75rem; 
-        &--title {
-            font-weight: bold; 
-        }
-        
-        z-index: 99; 
-
-        &--info {
-            height: 3rem; 
-        }
-
-        &--video-button {
-            all: unset; 
-            cursor: pointer; 
-            height: 2rem; 
-            margin: 0rem .5rem .5rem 0rem;
-        }
+      }
     }
 
-    &__work-hover-overlay:hover {
-        opacity: 1; 
-        background: linear-gradient(to bottom, transparent 0%, black 200%);
+    &--dark {
+      background: linear-gradient(to bottom, transparent 0%, black 200%);
+      color: white;
+      &:hover {
+        opacity: 1;
+      }
     }
+
+    font-family: $sans-serif-stack;
+    font-size: 0.75rem;
+    &--title {
+      font-weight: bold;
+    }
+
+    z-index: 99;
+
+    &--info {
+      height: 3rem;
+    }
+
+    &--video-button {
+      all: unset;
+      cursor: pointer;
+      height: 2rem;
+      margin: 0rem 0.5rem 0.5rem 0rem;
+    }
+  }
 }


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- add `hoveredStateTheme` field to Work model on Contentful([link](https://app.contentful.com/spaces/zb716c7gdesq/content_types/work/fields) to the model)
- make hovered state item style changed based on the `hoveredStateTheme` value(Dark or Light)

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
Closes #174 
QA ticket from Notion([link](https://www.notion.so/garden3d/create-a-toggle-to-select-whether-the-caption-should-show-in-white-or-black-35ee2b9e7f9f45ce8bdc6227f2d70294))

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
Tested with preview([all dark](https://sanctu-dot-k0rzbt12o-sanctucompu.vercel.app/)/[all light](https://sanctu-dot-m833i0vcy-sanctucompu.vercel.app/)) on Chrome

### Applicable screenshots

<!--- When appropriate, upload screenshots. -->

Dark: https://www.loom.com/share/ec5cc79aa000427f9c3671320a065d93

Light: https://www.loom.com/share/402908f79d6c408286370fa8aa8b394f

