### PR TITLE
QA: subtler hover transition

### DIFF
--- a/components/Work.js
+++ b/components/Work.js
@@ -85,9 +85,9 @@ const Work = ({ work, width = '100vw' }) => {
                   : 'WorkSectionAsGallery__work-hover-overlay--for-video'
               } flex justify-between items-end md:absolute relative`,
               {
-                'md:WorkSectionAsGallery__work-hover-overlay--dark WorkSectionAsGallery__work-hover-overlay--light':
+                'md:WorkSectionAsGallery__work-hover-overlay--white WorkSectionAsGallery__work-hover--black':
                   hoveredStateTheme === 'dark',
-                'WorkSectionAsGallery__work-hover-overlay--light':
+                'WorkSectionAsGallery__work-hover-overlay--black':
                   hoveredStateTheme === 'light',
               }
             )}

--- a/components/Work.js
+++ b/components/Work.js
@@ -79,7 +79,7 @@ const Work = ({ work, width = '100vw' }) => {
         >
           <div
             className={cx(
-              `WorkSectionAsGallery__work-hover-overlay pointer md:p1 p_625 ${
+              `WorkSectionAsGallery__work-hover-overlay pointer md:p1 py_625 px0 ${
                 workIsImage
                   ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
                   : 'WorkSectionAsGallery__work-hover-overlay--for-video'

--- a/components/Work.js
+++ b/components/Work.js
@@ -84,9 +84,9 @@ const Work = ({ work, width = '100vw' }) => {
               } flex justify-between items-end absolute`,
               {
                 'WorkSectionAsGallery__work-hover-overlay--dark':
-                  hoveredStateTheme === 'light',
-                'WorkSectionAsGallery__work-hover-overlay--light':
                   hoveredStateTheme === 'dark',
+                'WorkSectionAsGallery__work-hover-overlay--light':
+                  hoveredStateTheme === 'light',
               }
             )}
           >

--- a/components/Work.js
+++ b/components/Work.js
@@ -85,9 +85,9 @@ const Work = ({ work, width = '100vw' }) => {
               } flex justify-between items-end absolute`,
               {
                 'WorkSectionAsGallery__work-hover-overlay--dark':
-                  hoveredStateTheme === 'light',
-                'WorkSectionAsGallery__work-hover-overlay--light':
                   hoveredStateTheme === 'dark',
+                'WorkSectionAsGallery__work-hover-overlay--light':
+                  hoveredStateTheme === 'light',
               }
             )}
           >

--- a/components/Work.js
+++ b/components/Work.js
@@ -10,6 +10,7 @@ import { Image } from 'components/base';
 
 import get from 'utils/get';
 import flattenImageData from 'utils/flattenImageData';
+import cx from 'classnames';
 
 const PLAY_VIDEO = '(Play)';
 const PAUSE_VIDEO = '(Pause)';
@@ -51,6 +52,7 @@ const Work = ({ work, width = '100vw' }) => {
     ''
   ).startsWith('image/');
   const workImage = flattenImageData(get(work, 'fields.asset', {}));
+  const hoveredStateTheme = get(work, 'fields.hoveredStateTheme', 'Dark').toLowerCase();
   const title = get(work, 'fields.title', '');
   const caseStudySlug = get(work, 'fields.caseStudySlug', '');
   const link = get(work, 'fields.link', '');

--- a/components/Work.js
+++ b/components/Work.js
@@ -52,7 +52,11 @@ const Work = ({ work, width = '100vw' }) => {
     ''
   ).startsWith('image/');
   const workImage = flattenImageData(get(work, 'fields.asset', {}));
-  const hoveredStateTheme = get(work, 'fields.hoveredStateTheme', 'Dark').toLowerCase();
+  const hoveredStateTheme = get(
+    work,
+    'fields.hoveredStateTheme',
+    'Dark'
+  ).toLowerCase();
   const title = get(work, 'fields.title', '');
   const caseStudySlug = get(work, 'fields.caseStudySlug', '');
   const link = get(work, 'fields.link', '');
@@ -72,17 +76,25 @@ const Work = ({ work, width = '100vw' }) => {
           target={caseStudySlug ? '_self' : '_blank'}
         >
           <div
-            className={`WorkSectionAsGallery__work-hover-overlay pointer ${
-              workIsImage
-                ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
-                : 'WorkSectionAsGallery__work-hover-overlay--for-video'
-            } flex justify-between items-end color-white absolute`}
+            className={cx(
+              `WorkSectionAsGallery__work-hover-overlay pointer ${
+                workIsImage
+                  ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
+                  : 'WorkSectionAsGallery__work-hover-overlay--for-video'
+              } flex justify-between items-end absolute`,
+              {
+                'WorkSectionAsGallery__work-hover-overlay--dark':
+                  hoveredStateTheme === 'dark',
+                'WorkSectionAsGallery__work-hover-overlay--light':
+                  hoveredStateTheme === 'light',
+              }
+            )}
           >
             <div className="WorkSectionAsGallery__work-hover-overlay--info flex flex-col justify-evenly mb_5 ml_5">
               <div className="WorkSectionAsGallery__work-hover-overlay--title">
                 {title}
               </div>
-              <div className="decoration-none color-white">
+              <div className="decoration-none">
                 {caseStudySlug ? '(read case study)' : '→ visit the site'}
               </div>
             </div>

--- a/components/Work.js
+++ b/components/Work.js
@@ -10,6 +10,7 @@ import { Image } from 'components/base';
 
 import get from 'utils/get';
 import flattenImageData from 'utils/flattenImageData';
+
 import cx from 'classnames';
 
 const PLAY_VIDEO = '(Play)';

--- a/components/Work.js
+++ b/components/Work.js
@@ -65,18 +65,18 @@ const Work = ({ work, width = '100vw' }) => {
   const id = get(work, 'sys.id', '');
 
   return (
-    <div className='flex flex-col-reverse md:block'>
-      <Link href={caseStudySlug || link}>
-        <a
-          aria-label={
-            caseStudySlug
-              ? `read the case study for ${title}`
-              : `visit the site for ${title}`
-          }
-          rel="noopener noreferrer"
-          target={caseStudySlug ? '_self' : '_blank'}
-          className="decoration-none"
-        >
+    <Link href={caseStudySlug || link}>
+      <a
+        aria-label={
+          caseStudySlug
+            ? `read the case study for ${title}`
+            : `visit the site for ${title}`
+        }
+        rel="noopener noreferrer"
+        target={caseStudySlug ? '_self' : '_blank'}
+        className="decoration-none"
+      >
+        <div className="flex flex-col-reverse md:block">
           <div
             className={cx(
               `WorkSectionAsGallery__work-hover-overlay pointer md:p1 pt_625 pb1 px0 ${
@@ -85,9 +85,9 @@ const Work = ({ work, width = '100vw' }) => {
                   : 'WorkSectionAsGallery__work-hover-overlay--for-video'
               } flex justify-between items-end md:absolute relative`,
               {
-                'md:WorkSectionAsGallery__work-hover-overlay--white WorkSectionAsGallery__work-hover--black':
+                'WorkSectionAsGallery__work-hover-overlay--dark':
                   hoveredStateTheme === 'dark',
-                'WorkSectionAsGallery__work-hover-overlay--black':
+                'WorkSectionAsGallery__work-hover-overlay--light':
                   hoveredStateTheme === 'light',
               }
             )}
@@ -96,7 +96,7 @@ const Work = ({ work, width = '100vw' }) => {
               <div className="WorkSectionAsGallery__work-hover-overlay--title">
                 {title}
               </div>
-              <div className="decoration-none">
+              <div className="WorkSectionAsGallery__work-hover-overlay--caption">
                 {caseStudySlug ? '(read case study)' : '→ visit the site'}
               </div>
             </div>
@@ -116,31 +116,31 @@ const Work = ({ work, width = '100vw' }) => {
               </button>
             )}
           </div>
-        </a>
-      </Link>
-      {workIsImage ? (
-        <Image
-          alt={workImage.alt}
-          src={workImage.url}
-          width={workImage.width}
-          height={workImage.height}
-          sizes={width}
-        />
-      ) : (
-        <video
-          id={id}
-          key={id}
-          className="block w100 h100"
-          autoPlay
-          loop
-          muted
-          playsInline
-          ref={videoRef}
-        >
-          <source src={src}></source>
-        </video>
-      )}
-    </div>
+          {workIsImage ? (
+            <Image
+              alt={workImage.alt}
+              src={workImage.url}
+              width={workImage.width}
+              height={workImage.height}
+              sizes={width}
+            />
+          ) : (
+            <video
+              id={id}
+              key={id}
+              className="block w100 h100"
+              autoPlay
+              loop
+              muted
+              playsInline
+              ref={videoRef}
+            >
+              <source src={src}></source>
+            </video>
+          )}
+        </div>
+      </a>
+    </Link>
   );
 };
 

--- a/components/Work.js
+++ b/components/Work.js
@@ -85,9 +85,9 @@ const Work = ({ work, width = '100vw' }) => {
               } flex justify-between items-end absolute`,
               {
                 'WorkSectionAsGallery__work-hover-overlay--dark':
-                  hoveredStateTheme === 'dark',
-                'WorkSectionAsGallery__work-hover-overlay--light':
                   hoveredStateTheme === 'light',
+                'WorkSectionAsGallery__work-hover-overlay--light':
+                  hoveredStateTheme === 'dark',
               }
             )}
           >

--- a/components/Work.js
+++ b/components/Work.js
@@ -65,7 +65,7 @@ const Work = ({ work, width = '100vw' }) => {
   const id = get(work, 'sys.id', '');
 
   return (
-    <>
+    <div className='flex flex-col-reverse md:block'>
       <Link href={caseStudySlug || link}>
         <a
           aria-label={
@@ -75,6 +75,7 @@ const Work = ({ work, width = '100vw' }) => {
           }
           rel="noopener noreferrer"
           target={caseStudySlug ? '_self' : '_blank'}
+          className="decoration-none"
         >
           <div
             className={cx(
@@ -82,9 +83,9 @@ const Work = ({ work, width = '100vw' }) => {
                 workIsImage
                   ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
                   : 'WorkSectionAsGallery__work-hover-overlay--for-video'
-              } flex justify-between items-end absolute`,
+              } flex justify-between items-end md:absolute relative`,
               {
-                'WorkSectionAsGallery__work-hover-overlay--dark':
+                'md:WorkSectionAsGallery__work-hover-overlay--dark WorkSectionAsGallery__work-hover-overlay--light':
                   hoveredStateTheme === 'dark',
                 'WorkSectionAsGallery__work-hover-overlay--light':
                   hoveredStateTheme === 'light',
@@ -139,7 +140,7 @@ const Work = ({ work, width = '100vw' }) => {
           <source src={src}></source>
         </video>
       )}
-    </>
+    </div>
   );
 };
 

--- a/components/Work.js
+++ b/components/Work.js
@@ -79,7 +79,7 @@ const Work = ({ work, width = '100vw' }) => {
         >
           <div
             className={cx(
-              `WorkSectionAsGallery__work-hover-overlay pointer md:p1 py_625 px0 ${
+              `WorkSectionAsGallery__work-hover-overlay pointer md:p1 pt_625 pb1 px0 ${
                 workIsImage
                   ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
                   : 'WorkSectionAsGallery__work-hover-overlay--for-video'

--- a/components/WorkSectionAsGallery.js
+++ b/components/WorkSectionAsGallery.js
@@ -28,13 +28,13 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
           <div className="block col-8 mb_5 md:mb1 relative">
             <Work work={works[0]} />
           </div>
-          <div className="flex col-8 pb_5 md:pb1 items-end">
-            <div className="block col-4">
+          <div className="flex col-8 pb_5 md:pb1 items-end md:flex-row flex-col">
+            <div className="block md:col-4 col-8">
               <div className="relative">
                 <Work work={works[1]} width="50vw" />
               </div>
             </div>
-            <div className="block col-4 ml_5 md:ml1">
+            <div className="block md:col-4 col-8 mt_5 md:ml_5 md:ml1">
               <div className="relative">
                 <Work work={works[2]} width="50vw" />
               </div>
@@ -44,13 +44,13 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
       )}
       {!displayFirstAssetAsFullWidth && (
         <>
-          <div className="flex col-8 pb_5 md:pb1 items-end">
-            <div className="block col-4">
+          <div className="flex col-8 pb_5 md:pb1 items-end md:flex-row flex-col">
+            <div className="block md:col-4 col-8">
               <div className="relative">
                 <Work work={works[0]} width="50vw" />
               </div>
             </div>
-            <div className="block col-4 ml_5 md:ml1">
+            <div className="block md:col-4 col-8 mt_5 md:ml_5 md:ml1">
               <div className="relative">
                 <Work work={works[1]} width="50vw" />
               </div>

--- a/components/WorkSectionAsGallery.js
+++ b/components/WorkSectionAsGallery.js
@@ -25,7 +25,7 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
     <div className="flex-col pt_5 md:pt1 pr1 pl1">
       {displayFirstAssetAsFullWidth && (
         <>
-          <div className="block col-8 mb_5 md:mb1 relative">
+          <div className="block col-8 mb_625 md:mb1 relative">
             <Work work={works[0]} />
           </div>
           <div className="flex col-8 pb_5 md:pb1 items-end md:flex-row flex-col">
@@ -44,7 +44,7 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
       )}
       {!displayFirstAssetAsFullWidth && (
         <>
-          <div className="flex col-8 pb_5 md:pb1 items-end md:flex-row flex-col">
+          <div className="flex col-8 pb_625 md:pb1 items-end md:flex-row flex-col">
             <div className="block md:col-4 col-8">
               <div className="relative">
                 <Work work={works[0]} width="50vw" />

--- a/components/WorkSectionAsGallery.js
+++ b/components/WorkSectionAsGallery.js
@@ -25,7 +25,7 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
     <div className="flex-col pt_5 md:pt1 pr1 pl1">
       {displayFirstAssetAsFullWidth && (
         <>
-          <div className="block col-8 mb_625 md:mb1 relative">
+          <div className="block col-8 mb0 md:mb1 relative">
             <Work work={works[0]} />
           </div>
           <div className="flex col-8 pb_5 md:pb1 items-end md:flex-row flex-col">
@@ -34,7 +34,7 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
                 <Work work={works[1]} width="50vw" />
               </div>
             </div>
-            <div className="block md:col-4 col-8 mt_5 md:ml_5 md:ml1">
+            <div className="block md:col-4 col-8 md:ml_5 md:ml1">
               <div className="relative">
                 <Work work={works[2]} width="50vw" />
               </div>
@@ -44,13 +44,13 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
       )}
       {!displayFirstAssetAsFullWidth && (
         <>
-          <div className="flex col-8 pb_625 md:pb1 items-end md:flex-row flex-col">
+          <div className="flex col-8 pb0 md:pb1 items-end md:flex-row flex-col">
             <div className="block md:col-4 col-8">
               <div className="relative">
                 <Work work={works[0]} width="50vw" />
               </div>
             </div>
-            <div className="block md:col-4 col-8 mt_5 md:ml_5 md:ml1">
+            <div className="block md:col-4 col-8 md:ml_5 md:ml1">
               <div className="relative">
                 <Work work={works[1]} width="50vw" />
               </div>

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -19,7 +19,11 @@
     transition: all 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
 
     &--light {
-      background: linear-gradient(180deg, transparent 50%, hsla(0, 0%, 70%, 0.3) 120%);
+      background: linear-gradient(
+        180deg,
+        transparent 50%,
+        hsla(0, 0%, 70%, 0.3) 120%
+      );
       color: black;
       &:hover {
         opacity: 1;

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -20,9 +20,9 @@
 
     &--light {
       background: linear-gradient(
-        to bottom,
+        180deg,
         transparent 50%,
-        rgba(255, 255, 255, 0.6) 120%
+        hsla(0, 0%, 70%, 0.3) 120%
       );
       color: black;
       &:hover {

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -18,24 +18,14 @@
 
     transition: all 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
 
-    &--light {
-      // background: linear-gradient(
-      //   180deg,
-      //   transparent 50%,
-      //   hsla(0, 0%, 70%, 0.3) 120%
-      // );
+    &--black {
       color: black;
       &:hover {
         opacity: 1;
       }
     }
 
-    &--dark {
-      // background: linear-gradient(
-      //   to bottom,
-      //   transparent 50%,
-      //   rgba(0, 0, 0, 0.5) 150%
-      // );
+    &--white {
       color: white;
       &:hover {
         opacity: 1;

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -1,44 +1,54 @@
-.WorkSectionAsGallery{
-    &__work-hover-overlay {
-        &--for-image {
-            width: 100%; 
-            height: 100%;
-        }
+.WorkSectionAsGallery {
+  &__work-hover-overlay {
+    &--for-image {
+      width: 100%;
+      height: 100%;
+    }
 
-        &--for-video {
-            width: 100%; 
-            height: 99.5%; 
-        }
+    &--for-video {
+      width: 100%;
+      height: 99.5%;
+    }
 
+    opacity: 1;
+
+    @include media('lg-up') {
+      opacity: 0;
+    }
+
+    &--light {
+      background: linear-gradient(to bottom, transparent 0%, white 200%);
+      color: black;
+      &:hover {
         opacity: 1;
-
-        @include media('lg-up') {
-            opacity: 0;
-        }
-        background: linear-gradient(to bottom, transparent 0%, black 200%);
-
-        font-family: $sans-serif-stack;
-        font-size: .75rem; 
-        &--title {
-            font-weight: bold; 
-        }
-        
-        z-index: 99; 
-
-        &--info {
-            height: 3rem; 
-        }
-
-        &--video-button {
-            all: unset; 
-            cursor: pointer; 
-            height: 2rem; 
-            margin: 0rem .5rem .5rem 0rem;
-        }
+      }
     }
 
-    &__work-hover-overlay:hover {
-        opacity: 1; 
-        background: linear-gradient(to bottom, transparent 0%, black 200%);
+    &--dark {
+      background: linear-gradient(to bottom, transparent 0%, black 200%);
+      color: white;
+      &:hover {
+        opacity: 1;
+      }
     }
+
+    font-family: $sans-serif-stack;
+    font-size: 0.75rem;
+    &--title {
+      font-weight: bold;
+    }
+
+    z-index: 99;
+
+    &--info {
+      height: 3rem;
+    }
+
+    &--video-button {
+      all: unset;
+      cursor: pointer;
+      height: 2rem;
+      margin: 0rem 0.5rem 0.5rem 0rem;
+    }
+  }
 }

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -32,6 +32,7 @@
       }
       @include media('md') {
         color: white;
+        background: linear-gradient(180deg,transparent 50%,rgba(0,0,0,.5) 150%);
       }
     }
 

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -18,17 +18,20 @@
 
     transition: all 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
 
-    &--black {
+    &--light {
       color: black;
       &:hover {
         opacity: 1;
       }
     }
 
-    &--white {
-      color: white;
+    &--dark {
+      color: black;
       &:hover {
         opacity: 1;
+      }
+      @include media('md') {
+        color: white;
       }
     }
 
@@ -39,6 +42,7 @@
     @include media('md') {
       line-height: 1.5rem;
     }
+
     &--title {
       font-weight: bold;
     }

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -20,9 +20,9 @@
 
     &--light {
       background: linear-gradient(
-        180deg,
+        to bottom,
         transparent 50%,
-        hsla(0, 0%, 70%, 0.3) 120%
+        rgba(255, 255, 255, 0.6) 120%
       );
       color: black;
       &:hover {

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -22,7 +22,7 @@
       background: linear-gradient(
         to bottom,
         transparent 50%,
-        rgba(255, 255, 255, 0.6) 150%
+        rgba(255, 255, 255, 0.6) 120%
       );
       color: black;
       &:hover {

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -16,11 +16,13 @@
       opacity: 0;
     }
 
+    transition: all 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
+
     &--light {
       background: linear-gradient(
         to bottom,
-        transparent 0%,
-        color('white') 200%
+        transparent 50%,
+        rgba(255, 255, 255, 0.6) 150%
       );
       color: black;
       &:hover {
@@ -29,7 +31,11 @@
     }
 
     &--dark {
-      background: linear-gradient(to bottom, transparent 0%, black 200%);
+      background: linear-gradient(
+        to bottom,
+        transparent 50%,
+        rgba(0, 0, 0, 0.5) 150%
+      );
       color: white;
       &:hover {
         opacity: 1;

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -19,11 +19,7 @@
     transition: all 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
 
     &--light {
-      background: linear-gradient(
-        to bottom,
-        transparent 50%,
-        rgba(255, 255, 255, 0.6) 120%
-      );
+      background: linear-gradient(180deg, transparent 50%, hsla(0, 0%, 70%, 0.3) 120%);
       color: black;
       &:hover {
         opacity: 1;

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -19,11 +19,11 @@
     transition: all 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
 
     &--light {
-      background: linear-gradient(
-        180deg,
-        transparent 50%,
-        hsla(0, 0%, 70%, 0.3) 120%
-      );
+      // background: linear-gradient(
+      //   180deg,
+      //   transparent 50%,
+      //   hsla(0, 0%, 70%, 0.3) 120%
+      // );
       color: black;
       &:hover {
         opacity: 1;
@@ -31,11 +31,11 @@
     }
 
     &--dark {
-      background: linear-gradient(
-        to bottom,
-        transparent 50%,
-        rgba(0, 0, 0, 0.5) 150%
-      );
+      // background: linear-gradient(
+      //   to bottom,
+      //   transparent 50%,
+      //   rgba(0, 0, 0, 0.5) 150%
+      // );
       color: white;
       &:hover {
         opacity: 1;


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- add transition to hover state change 
- make hover gradient color more transparent to make the layer more subtle

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
Closes #175 
QA ticket from Notion([link](https://www.notion.so/garden3d/There-should-be-a-graceful-on-brand-transition-for-the-hover-state-636ae69f018242658169ebc847bd9ab4))

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
Tested with [preview](https://sanctu-dot-776f11xpu-sanctucompu.vercel.app/) on desktop Chrome/Safari

### Applicable screenshots

<!--- When appropriate, upload screenshots. -->
transition on dark layer : https://www.loom.com/share/8ad1ff670be54ff2912f4fc729b53f32
transition on light layer : 

