### PR TITLE
QA: add medium weight san serif font to style

### DIFF
--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -32,7 +32,11 @@
       }
       @include media('md') {
         color: white;
-        background: linear-gradient(180deg,transparent 50%,rgba(0,0,0,.5) 150%);
+        background: linear-gradient(
+          180deg,
+          transparent 50%,
+          rgba(0, 0, 0, 0.5) 150%
+        );
       }
     }
 
@@ -45,7 +49,7 @@
     }
 
     &--title {
-      font-weight: bold;
+      font-weight: 500;
     }
 
     z-index: 99;

--- a/styles/fontface.scss
+++ b/styles/fontface.scss
@@ -87,3 +87,18 @@
   font-stretch: normal;
   font-display: swap;
 }
+
+@font-face {
+  font-family: 'Atlas Grotesk Web';
+  src: url('https://fonts.sanctuary.computer/AtlasGrotesk/AtlasGrotesk-Medium-Web.eot');
+  src: url('https://fonts.sanctuary.computer/AtlasGrotesk/AtlasGrotesk-Medium-Web.eot?#iefix')
+      format('embedded-opentype'),
+    url('https://fonts.sanctuary.computer/AtlasGrotesk/AtlasGrotesk-Medium-Web.woff2')
+      format('woff2'),
+    url('https://fonts.sanctuary.computer/AtlasGrotesk/AtlasGrotesk-Medium-Web.woff')
+      format('woff');
+  font-weight: 500;
+  font-style: normal;
+  font-stretch: normal;
+  font-display: swap;
+}


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- add Atlas Grotesk Medium font to style and use it in bold text to solve fuzzy bold type issue on mobile

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
QA item from Notion([LINK](https://www.notion.so/garden3d/Ensure-mobile-and-desktop-type-styles-are-the-same-c39152885650445c86255ff0ab044144))

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
Tested with the [preview link](https://sanctu-dot-32jhg393n-sanctucompu.vercel.app/) both on desktop and mobile browsers

### Applicable screenshots

- before
![IMG_0147](https://user-images.githubusercontent.com/12539032/217650624-ed0da08c-afd8-46a3-874c-eca1e31121a8.PNG)

- after
![IMG_0145](https://user-images.githubusercontent.com/12539032/217649731-d3f3aef1-fbe1-4e67-aff9-cb4f10a71d3f.PNG)


### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
