### PR TITLE
QA: give more space between work gallery items

### DIFF
--- a/components/Gallery.js
+++ b/components/Gallery.js
@@ -92,7 +92,7 @@ class Gallery extends PureComponent {
     );
 
     return (
-      <div className="col-8 p1 flex flex-wrap overflow-hidden">
+      <div className="col-8 p1 md:pt1 pt2 flex flex-wrap overflow-hidden">
         {imageMatrix.map((imageGroup, index) =>
           this.renderGalleryRow(imageGroup, index, imageMatrix)
         )}

--- a/components/Work.js
+++ b/components/Work.js
@@ -79,7 +79,7 @@ const Work = ({ work, width = '100vw' }) => {
         <div className="flex flex-col-reverse md:block">
           <div
             className={cx(
-              `WorkSectionAsGallery__work-hover-overlay pointer md:p1 pt_625 pb1 px0 ${
+              `WorkSectionAsGallery__work-hover-overlay pointer md:p1 pt_625 pb2 px0 ${
                 workIsImage
                   ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
                   : 'WorkSectionAsGallery__work-hover-overlay--for-video'

--- a/components/Work.js
+++ b/components/Work.js
@@ -79,7 +79,7 @@ const Work = ({ work, width = '100vw' }) => {
         <div className="flex flex-col-reverse md:block">
           <div
             className={cx(
-              `WorkSectionAsGallery__work-hover-overlay pointer md:p1 pt_625 pb2 px0 ${
+              `WorkSectionAsGallery__work-hover-overlay pointer md:p1 pt_625 px0 ${
                 workIsImage
                   ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
                   : 'WorkSectionAsGallery__work-hover-overlay--for-video'

--- a/components/WorkSectionAsGallery.js
+++ b/components/WorkSectionAsGallery.js
@@ -25,11 +25,11 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
     <div className="flex-col pt_5 md:pt1 pr1 pl1">
       {displayFirstAssetAsFullWidth && (
         <>
-          <div className="block col-8 mb0 md:mb1 relative">
+          <div className="block col-8 md:mb1 relative mb2">
             <Work work={works[0]} />
           </div>
           <div className="flex col-8 pb_5 md:pb1 items-end md:flex-row flex-col">
-            <div className="block md:col-4 col-8">
+            <div className="block md:col-4 col-8 md:mb0 mb2">
               <div className="relative">
                 <Work work={works[1]} width="50vw" />
               </div>
@@ -45,12 +45,12 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
       {!displayFirstAssetAsFullWidth && (
         <>
           <div className="flex col-8 pb0 md:pb1 items-end md:flex-row flex-col">
-            <div className="block md:col-4 col-8">
+            <div className="block md:col-4 col-8 md:mb0 mb2">
               <div className="relative">
                 <Work work={works[0]} width="50vw" />
               </div>
             </div>
-            <div className="block md:col-4 col-8 md:ml_5 md:ml1">
+            <div className="block md:col-4 col-8 md:ml_5 md:ml1 md:mb0 mb2">
               <div className="relative">
                 <Work work={works[1]} width="50vw" />
               </div>
@@ -75,7 +75,7 @@ const WorkGalleryTextBlock = ({ textBlock }) => {
     <div>
       {text && (
         <Markdown
-          className="WorkSectionAsGallery__work-gallery-text px1_25 py5 md:p13 Markdown--medium"
+          className="WorkSectionAsGallery__work-gallery-text px1_25 py5 md:p13 md:mt1 mt0 Markdown--medium"
           src={text}
         />
       )}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "next lint --allow-empty",
     "prepare": "husky install"
   },
   "dependencies": {

--- a/styles/components/Block.scss
+++ b/styles/components/Block.scss
@@ -1,5 +1,0 @@
-.Block {
-  div > span > p {
-    line-height: 1.5rem;
-  }
-}

--- a/styles/components/Block.scss
+++ b/styles/components/Block.scss
@@ -1,0 +1,5 @@
+.Block {
+  div > span > p {
+    line-height: 1.5rem;
+  }
+}

--- a/styles/components/Markdown.scss
+++ b/styles/components/Markdown.scss
@@ -9,6 +9,9 @@
     @include media('xl') {
       margin-bottom: $p-xl-line-height;
     }
+    &:last-child {
+      margin-bottom: 0;
+    }
 
     > em {
       @extend .tiny;


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- Add more spacing between work gallery items on mobile to clarify where the captions belong to which one

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
QA item from Notion([LINK](https://www.notion.so/garden3d/Add-bottom-margin-to-Work-blocks-a3a8cd3fb82d4160a01e7ff7ea54b453))

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
Tested with the [preview link](https://sanctu-dot-meg795ne7-sanctucompu.vercel.app/) on mobile browsers

### Applicable screenshots

<!--- When appropriate, upload screenshots. -->
<img width="367" alt="Screen Shot 2023-02-08 at 4 47 19 PM" src="https://user-images.githubusercontent.com/12539032/217658606-79b8f1c1-5623-48bc-b79a-8f43c2e06807.png">


### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
