### PR TITLE
QA: change percentage of gradient spread

### DIFF
--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -32,7 +32,11 @@
       }
       @include media('md') {
         color: white;
-        background: linear-gradient(180deg,transparent 50%,rgba(0,0,0,.5) 150%);
+        background: linear-gradient(
+          180deg,
+          transparent 80%,
+          rgba(0, 0, 0, 0.5) 130%
+        );
       }
     }
 


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- adjust the gradient spread value to prevent black overlay displayed over the white space of some images

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
QA item from Notion([LINK](https://www.notion.so/garden3d/Adjust-overlay-gradient-spread-level-2758522ba2fb4cc580f751c6ef4a55ca))
Related Twist thread([LINK](https://twist.com/a/133876/ch/552738/t/4052838/c/81732059))

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
Tested with the [preview link](https://sanctu-dot-5gxtf2ctx-sanctucompu.vercel.app/) on desktop browser

### Applicable screenshots

<!--- When appropriate, upload screenshots. -->
- before: 
<img width="1408" alt="Screen Shot 2023-02-08 at 4 51 05 PM" src="https://user-images.githubusercontent.com/12539032/217659282-fe96b2e5-6c11-4c95-9240-f3957b9174c9.png">

- after:
<img width="1407" alt="Screen Shot 2023-02-08 at 4 50 53 PM" src="https://user-images.githubusercontent.com/12539032/217659306-e143cdb7-d535-44a2-aecd-f99561967b8c.png">


### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
