### PR TITLE
QA: add line height to keep the consistency on Case Study pages

### DIFF
--- a/styles/components/BlockGeneralInfo.scss
+++ b/styles/components/BlockGeneralInfo.scss
@@ -1,3 +1,6 @@
 .BlockGeneralInfo {
   min-height: 25.25rem;
+  div > span > p {
+    line-height: 1.5rem;
+  }
 }

--- a/styles/components/BlockImageText.scss
+++ b/styles/components/BlockImageText.scss
@@ -1,6 +1,7 @@
 .BlockImageText {
   &__description > div > span > p {
     padding-bottom: 2rem;
+    line-height: 1.5rem;
 
     &:last-child {
       padding-bottom: 0;


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- add `line-height` attribute to long text formats on Block to keep consistent line height over Case Study pages

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
- QA item from Notion([LINK](https://www.notion.so/garden3d/Line-Height-in-Case-Studies-should-be-consistent-ad369ab5922b4c7784892557e38bb636))

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
Tested with [the preview link](https://sanctu-dot-g7m978u5j-sanctucompu.vercel.app/loupe-this) both on desktop and mobile browser

### Applicable screenshots

<!--- When appropriate, upload screenshots. -->
https://www.loom.com/share/fc7d5dd58be240be851974b59f31ffbe

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
