### PR TITLE
QA: make overlay and alignment optional for items of Work Gallery 

### DIFF
--- a/components/Work.js
+++ b/components/Work.js
@@ -53,15 +53,11 @@ const Work = ({ work, width = '100vw' }) => {
     ''
   ).startsWith('image/');
   const workImage = flattenImageData(get(work, 'fields.asset', {}));
-  const hoveredStateTheme = get(
-    work,
-    'fields.hoveredStateTheme',
-    'Dark'
-  ).toLowerCase();
+  const hoveredStateTheme = get(work, 'fields.hoveredStateTheme', 'dark');
   const disableOverlayOnDarkTheme = get(
     work,
     'fields.disableOverlayOnDarkTheme',
-    'false'
+    false
   );
   const title = get(work, 'fields.title', '');
   const caseStudySlug = get(work, 'fields.caseStudySlug', '');
@@ -89,8 +85,7 @@ const Work = ({ work, width = '100vw' }) => {
                 'WorkSectionAsGallery__work-hover-overlay--dark':
                   hoveredStateTheme === 'dark',
                 'WorkSectionAsGallery__work-hover-overlay--dark-gradient':
-                  hoveredStateTheme === 'dark' &&
-                  disableOverlayOnDarkTheme === 'false',
+                  hoveredStateTheme === 'dark' && !disableOverlayOnDarkTheme,
                 'WorkSectionAsGallery__work-hover-overlay--light':
                   hoveredStateTheme === 'light',
                 'WorkSectionAsGallery__work-hover-overlay--for-image':

--- a/components/Work.js
+++ b/components/Work.js
@@ -58,6 +58,11 @@ const Work = ({ work, width = '100vw' }) => {
     'fields.hoveredStateTheme',
     'Dark'
   ).toLowerCase();
+  const disableOverlayOnDarkTheme = get(
+    work,
+    'fields.disableOverlayOnDarkTheme',
+    'false'
+  );
   const title = get(work, 'fields.title', '');
   const caseStudySlug = get(work, 'fields.caseStudySlug', '');
   const link = get(work, 'fields.link', '');
@@ -79,16 +84,19 @@ const Work = ({ work, width = '100vw' }) => {
         <div className="flex flex-col-reverse md:block">
           <div
             className={cx(
-              `WorkSectionAsGallery__work-hover-overlay pointer md:p1 pt_625 pb1 px0 ${
-                workIsImage
-                  ? 'WorkSectionAsGallery__work-hover-overlay--for-image'
-                  : 'WorkSectionAsGallery__work-hover-overlay--for-video'
-              } flex justify-between items-end md:absolute relative`,
+              `WorkSectionAsGallery__work-hover-overlay pointer md:p1 pt_625 pb1 px0 flex justify-between items-end md:absolute relative`,
               {
                 'WorkSectionAsGallery__work-hover-overlay--dark':
                   hoveredStateTheme === 'dark',
+                'WorkSectionAsGallery__work-hover-overlay--dark-gradient':
+                  hoveredStateTheme === 'dark' &&
+                  disableOverlayOnDarkTheme === 'false',
                 'WorkSectionAsGallery__work-hover-overlay--light':
                   hoveredStateTheme === 'light',
+                'WorkSectionAsGallery__work-hover-overlay--for-image':
+                  workIsImage,
+                'WorkSectionAsGallery__work-hover-overlay--for-video':
+                  !workIsImage,
               }
             )}
           >

--- a/components/WorkSectionAsGallery.js
+++ b/components/WorkSectionAsGallery.js
@@ -8,6 +8,7 @@ import { Markdown } from 'components/base';
 import Work from 'components/Work';
 
 import get from 'utils/get';
+import cx from 'classnames';
 
 const WorkGalleryAssetBlock = ({ assetBlock }) => {
   if (!assetBlock) {
@@ -20,6 +21,11 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
     true
   );
   const works = get(assetBlock, 'fields.works', []);
+  const doubleColumnRowAlignment = get(
+    assetBlock,
+    'fields.doubleColumnRowAlignment',
+    'bottom'
+  );
 
   return (
     <div className="flex-col pt_5 md:pt1 pr1 pl1">
@@ -28,7 +34,12 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
           <div className="block col-8 mb0 md:mb1 relative">
             <Work work={works[0]} />
           </div>
-          <div className="flex col-8 pb_5 md:pb1 items-end md:flex-row flex-col">
+          <div
+            className={cx('flex col-8 pb_5 md:pb1 md:flex-row flex-col', {
+              'items-start': doubleColumnRowAlignment === 'top',
+              'items-end': doubleColumnRowAlignment === 'bottom',
+            })}
+          >
             <div className="block md:col-4 col-8">
               <div className="relative">
                 <Work work={works[1]} width="50vw" />
@@ -44,7 +55,12 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
       )}
       {!displayFirstAssetAsFullWidth && (
         <>
-          <div className="flex col-8 pb0 md:pb1 items-end md:flex-row flex-col">
+          <div
+            className={cx('flex col-8 pb0 md:pb1 md:flex-row flex-col', {
+              'items-start': doubleColumnRowAlignment === 'top',
+              'items-end': doubleColumnRowAlignment === 'bottom',
+            })}
+          >
             <div className="block md:col-4 col-8">
               <div className="relative">
                 <Work work={works[0]} width="50vw" />

--- a/components/WorkSectionAsGallery.js
+++ b/components/WorkSectionAsGallery.js
@@ -21,9 +21,9 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
     true
   );
   const works = get(assetBlock, 'fields.works', []);
-  const doubleColumnRowAlignment = get(
+  const doubleColumnVerticalAlignment = get(
     assetBlock,
-    'fields.doubleColumnRowAlignment',
+    'fields.doubleColumnVerticalAlignment',
     'bottom'
   );
 
@@ -36,8 +36,8 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
           </div>
           <div
             className={cx('flex col-8 pb_5 md:pb1 md:flex-row flex-col', {
-              'items-start': doubleColumnRowAlignment === 'top',
-              'items-end': doubleColumnRowAlignment === 'bottom',
+              'items-start': doubleColumnVerticalAlignment === 'top',
+              'items-end': doubleColumnVerticalAlignment === 'bottom',
             })}
           >
             <div className="block md:col-4 col-8">
@@ -57,8 +57,8 @@ const WorkGalleryAssetBlock = ({ assetBlock }) => {
         <>
           <div
             className={cx('flex col-8 pb0 md:pb1 md:flex-row flex-col', {
-              'items-start': doubleColumnRowAlignment === 'top',
-              'items-end': doubleColumnRowAlignment === 'bottom',
+              'items-start': doubleColumnVerticalAlignment === 'top',
+              'items-end': doubleColumnVerticalAlignment === 'bottom',
             })}
           >
             <div className="block md:col-4 col-8">

--- a/styles/components/WorkSectionAsGallery.scss
+++ b/styles/components/WorkSectionAsGallery.scss
@@ -32,6 +32,11 @@
       }
       @include media('md') {
         color: white;
+      }
+    }
+
+    &--dark-gradient {
+      @include media('md') {
         background: linear-gradient(
           180deg,
           transparent 80%,


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- add 'Disable Overlay On Dark Theme' field to Work model on [Contentful](https://app.contentful.com/spaces/zb716c7gdesq/content_types/work/fields) to make hover state bg background for dark theme optional on Work Gallery
- add 'Double Column Row Alignment' field to Work Gallery Block on [Contentful](https://app.contentful.com/spaces/zb716c7gdesq/content_types/workGalleryBlockFullWidthAsset2Assets/fields) to make top/bottom alignment optional on Work Gallery
-> add class conditions to apply these field values to UI

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix
- [ ] New feature
- [x] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
QA items from Notion
- [Side by side Image Blocks should be configurable](https://www.notion.so/garden3d/Side-by-side-Image-Blocks-should-be-configurable-so-they-can-align-to-the-top-of-the-row-in-some-cas-d1e0cbe56240492ca623a05ac22f60fa?pvs=4)
- [Elie should be able to disable the overlay](https://www.notion.so/garden3d/Elie-should-be-able-to-disable-the-overlay-even-if-the-asset-is-configured-to-use-white-text-f285ac1f1cb74f2f888abd03edd3a654?pvs=4)

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
Tested with [preview link](https://sanctu-dot-o407udbhk-sanctucompu.vercel.app/) on desktop and mobile browser

### Applicable screenshots

<!--- When appropriate, upload screenshots. -->
- vertical alignment of WG items
-> before(no options, only bottom alignment):
<img width="1260" alt="Screen Shot 2023-02-09 at 7 27 33 PM" src="https://user-images.githubusercontent.com/12539032/217970051-063e7119-20fc-4695-88e8-932a16c29cb6.png">

-> after(same block after setting `doubleColumnRowAlignment` to 'Top'):
<img width="1263" alt="Screen Shot 2023-02-09 at 7 27 48 PM" src="https://user-images.githubusercontent.com/12539032/217970169-c99e1cbf-827f-4979-b803-43b8e8f2c8d0.png">


- disable overlay on dark themes
-> before(no option to turn off the bg overlay on dark theme):
<img width="1262" alt="Screen Shot 2023-02-09 at 7 28 25 PM" src="https://user-images.githubusercontent.com/12539032/217970195-6d95b776-de7c-4809-953e-93b53f2d3bf4.png">

-> after(same Work item after setting `disableOverlayOnDarkTheme` to 'True'):
<img width="1261" alt="Screen Shot 2023-02-09 at 7 28 02 PM" src="https://user-images.githubusercontent.com/12539032/217970308-7929eed6-52c9-4952-b77c-0bc144fad997.png">


### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
