### PR TITLE
QA: fix sticky position of Gallery block

### DIFF
--- a/components/Gallery.js
+++ b/components/Gallery.js
@@ -92,7 +92,7 @@ class Gallery extends PureComponent {
     );
 
     return (
-      <div className="col-8 p1 flex flex-wrap">
+      <div className="Gallery col-8 p1 flex flex-wrap">
         {imageMatrix.map((imageGroup, index) =>
           this.renderGalleryRow(imageGroup, index, imageMatrix)
         )}

--- a/components/Gallery.js
+++ b/components/Gallery.js
@@ -92,7 +92,7 @@ class Gallery extends PureComponent {
     );
 
     return (
-      <div className="Gallery col-8 p1 flex flex-wrap">
+      <div className="overflow-x-hidden md:overflow-x-visible col-8 p1 flex flex-wrap">
         {imageMatrix.map((imageGroup, index) =>
           this.renderGalleryRow(imageGroup, index, imageMatrix)
         )}

--- a/components/Gallery.js
+++ b/components/Gallery.js
@@ -92,7 +92,7 @@ class Gallery extends PureComponent {
     );
 
     return (
-      <div className="col-8 p1 flex flex-wrap overflow-hidden">
+      <div className="col-8 p1 flex flex-wrap">
         {imageMatrix.map((imageGroup, index) =>
           this.renderGalleryRow(imageGroup, index, imageMatrix)
         )}

--- a/styles/components.scss
+++ b/styles/components.scss
@@ -22,3 +22,4 @@
 @import './components/BlockFooterWithLists.scss';
 @import './components/BlockImage.scss';
 @import './components/BlockVideo.scss';
+@import './components/Gallery.scss';

--- a/styles/components.scss
+++ b/styles/components.scss
@@ -22,4 +22,3 @@
 @import './components/BlockFooterWithLists.scss';
 @import './components/BlockImage.scss';
 @import './components/BlockVideo.scss';
-@import './components/Gallery.scss';

--- a/styles/components/Gallery.scss
+++ b/styles/components/Gallery.scss
@@ -1,0 +1,6 @@
+.Gallery {
+  overflow-x: hidden;
+  @include media('md') {
+    overflow-x: visible;
+  }
+}

--- a/styles/components/Gallery.scss
+++ b/styles/components/Gallery.scss
@@ -1,6 +1,0 @@
-.Gallery {
-  overflow-x: hidden;
-  @include media('md') {
-    overflow-x: visible;
-  }
-}

--- a/styles/config.scss
+++ b/styles/config.scss
@@ -19,3 +19,11 @@ $spacing-units: 0rem, 0.25rem, 0.5rem, 0.625rem, 0.75rem, 1rem, 1.25rem, 1.5rem,
   15rem;
 
 $grid-columns: 8;
+
+$additional-class-definitions: (
+  'overflow-x-visible': (
+    overflow-x: visible,
+  ),
+);
+
+$additional-responsive-classes: (overflow-x-visible);


### PR DESCRIPTION
### Description

<!--- Summarize the changes that can be found in this PR and how your reviewers should test these changes. -->
- remove `overflow-hidden` from Gallery container to fix not working sticky position setup for Gallery text 

### Type(s) of changes

<!--- Put an `x` in all the boxes that apply. -->

- [x] Bug fix
- [ ] New feature
- [ ] Update to an existing feature

### Motivation for PR

<!--- If it addresses an open issue, please link to the issue here, otherwise, briefly describe the issue. -->
QA item from Notion
- [the sticky effect from the live website has been broken](https://www.notion.so/garden3d/It-appears-the-sticky-effect-from-the-live-website-has-been-broken-in-the-preview-link-a1b7d642bfc4402188006e550509bc9a?pvs=4)

### How Has This Been Tested?

<!--- Please note how you have tested your changes. Browsers, accessibility, devices, unit tests, etc. -->
- Tested with [preview link](https://sanctu-dot-md7x363fb-sanctucompu.vercel.app/) on desktop browser

### Applicable screenshots

<!--- When appropriate, upload screenshots. -->
https://www.loom.com/share/5c5a0952ead14564b1840db82f1e3968

### Follow-up PR

<!--- When appropriate, please note what your reviewers can expect in a follow up PR. -->
